### PR TITLE
Stop when steady

### DIFF
--- a/Exec/run2d/inputs.2d.lid_driven_cavity
+++ b/Exec/run2d/inputs.2d.lid_driven_cavity
@@ -6,15 +6,19 @@
 
 # Maximum number of coarse grid timesteps to be taken, if stop_time is
 #  not reached first.
-max_step 				= -1
+max_step 				= 100000
 
 # Time at which calculation stops, if max_step is not reached first.
-stop_time 				= 50.0
+stop_time 				= -1
+
+# Stop simulation when we reach steady-state
+ns.stop_when_steady 	= 1
+ns.steady_tol 			= 1.0e-5
 
 #*******************************************************************************
 
 # Number of cells in each coordinate direction at the coarsest level
-amr.n_cell 				= 64 64
+amr.n_cell 				= 128 128
 amr.max_grid_size		= 16
 
 #*******************************************************************************
@@ -105,7 +109,7 @@ ns.hi_bc             	= 5 5
 #*******************************************************************************
 
 # Continue from checkpoint 
-# amr.restart 			= chk00927
+# amr.restart 			= chk02607
 
 #*******************************************************************************
 

--- a/Exec/run2d/inputs.2d.poiseuille
+++ b/Exec/run2d/inputs.2d.poiseuille
@@ -6,10 +6,14 @@
 
 # Maximum number of coarse grid timesteps to be taken, if stop_time is
 #  not reached first.
-max_step 				= -1
+max_step 				= 1000
 
 # Time at which calculation stops, if max_step is not reached first.
-stop_time 				= 10.0
+stop_time 				= -1
+
+# Tolerance for assuming system has reached steady-state
+ns.stop_when_steady 	= 1
+ns.steady_tol 			= 1.0e-5
 
 #*******************************************************************************
 
@@ -25,7 +29,7 @@ amr.max_level			= 0 # maximum number of levels of refinement
 #*******************************************************************************
 
 # Sets the "NavierStokes" code to not be verbose
-ns.v                    = 0
+ns.v                    = 1
 
 #*******************************************************************************
 
@@ -45,7 +49,7 @@ amr.plot_int			= 10
 #*******************************************************************************
 
 # CFL number to be used in calculating the time step : dt = dx / max(velocity)
-ns.cfl                  = 0.7  # CFL number used to set dt
+ns.cfl                  = 0.5  # CFL number used to set dt
 
 #*******************************************************************************
 

--- a/Exec/run3d/inputs.3d.lid_driven_cavity
+++ b/Exec/run3d/inputs.3d.lid_driven_cavity
@@ -6,7 +6,10 @@ max_step                =  -1
 
 stop_time 				=  10.0
 
-amr.n_cell              =  32 32 32
+ns.stop_when_steady 	=  1
+ns.steady_tol 			=  1.0e-4
+
+amr.n_cell              =  64 64 64
 
 amr.max_level           =  0
 

--- a/Exec/run3d/inputs.3d.poiseuille
+++ b/Exec/run3d/inputs.3d.poiseuille
@@ -1,23 +1,26 @@
 #*******************************************************************************
-# INPUTS.3D.LID_DRIVEN_CAVITY
+# INPUTS.3D.POISEUILLE
 #*******************************************************************************
 
-max_step                =  -1
+max_step                =  1000
 
-stop_time 				=  1.0
+stop_time 				=  -1
+
+ns.stop_when_steady 	=  1
+ns.steady_tol 			=  1.0e-4
 
 amr.n_cell              =  32 32 32
 
 amr.max_level           =  0
 
-ns.v                    =  0
+ns.v                    =  1
 amr.v                   =  1
 
-amr.check_int			=  100
+amr.check_int			=  1000
 
-amr.plot_int			=  1
+amr.plot_int			=  10
 
-ns.cfl                  =  0.7  # CFL number used to set dt
+ns.cfl                  =  0.5  # CFL number used to set dt
 
 ns.init_shrink          =  0.3  # factor which multiplies the very first time step
 ns.init_iter          	=  3    # number of initial iterations

--- a/Source/GODUNOV_F.H
+++ b/Source/GODUNOV_F.H
@@ -6,6 +6,7 @@
 #    define FORT_TEST_U_RHO         testurho
 #    define FORT_TEST_UMAC_RHO      testumacrho
 #    define FORT_ESTDT              estmdt
+#    define FORT_MAXCHANGE          maxchange
 #    define FORT_TRANSVEL           transvel
 #    define FORT_ESTATE             estate
 #    define FORT_ESTATE_FPU         estatefpu
@@ -28,6 +29,7 @@
 #    define FORT_TEST_U_RHO         TESTURHO 
 #    define FORT_TEST_UMAC_RHO      TESTUMACRHO
 #    define FORT_ESTDT              ESTMDT 
+#    define FORT_MAXCHANGE          MAXCHANGE
 #    define FORT_TRANSVEL           TRANSVEL  
 #    define FORT_ESTATE             ESTATE    
 #    define FORT_ESTATE_FPU         ESTATEFPU
@@ -49,6 +51,7 @@
 #    define FORT_TEST_U_RHO         testurho
 #    define FORT_TEST_UMAC_RHO      testumacrho
 #    define FORT_ESTDT              estmdt
+#    define FORT_MAXCHANGE          maxchange
 #    define FORT_TRANSVEL           transvel
 #    define FORT_ESTATE             estate
 #    define FORT_ESTATE_FPU         estatefpu
@@ -70,6 +73,7 @@
 #    define FORT_TEST_U_RHO         testurho_
 #    define FORT_TEST_UMAC_RHO      testumacrho_
 #    define FORT_ESTDT              estmdt_
+#    define FORT_MAXCHANGE          maxchange_
 #    define FORT_TRANSVEL           transvel_
 #    define FORT_ESTATE             estate_
 #    define FORT_ESTATE_FPU         estatefpu_
@@ -119,6 +123,10 @@ extern "C"
 		   const amrex::Real* rdat,  ARLIM_P(rlo), ARLIM_P(rhi),
 		   const int* lo, const int* hi, amrex::Real* dt, 
 		   const amrex::Real* dx, amrex::Real* cfl, amrex::Real* u_max);
+   
+   void FORT_MAXCHANGE(const amrex::Real* Uodat,  ARLIM_P(uo_lo), ARLIM_P(uo_hi),
+		   const amrex::Real* Undat,  ARLIM_P(un_lo), ARLIM_P(un_hi),
+		   const int* lo, const int* hi, amrex::Real* max_change);
    
    void FORT_TRANSVEL( const amrex::Real* u_dat, const amrex::Real* uad_dat, 
 		       const amrex::Real* xhi_dat, const amrex::Real* slx_dat, 

--- a/Source/GODUNOV_F.H
+++ b/Source/GODUNOV_F.H
@@ -6,7 +6,7 @@
 #    define FORT_TEST_U_RHO         testurho
 #    define FORT_TEST_UMAC_RHO      testumacrho
 #    define FORT_ESTDT              estmdt
-#    define FORT_MAXCHANGE          maxchange
+#    define FORT_MAXCHNG_VELMAG     maxchngvelmag
 #    define FORT_TRANSVEL           transvel
 #    define FORT_ESTATE             estate
 #    define FORT_ESTATE_FPU         estatefpu
@@ -29,7 +29,7 @@
 #    define FORT_TEST_U_RHO         TESTURHO 
 #    define FORT_TEST_UMAC_RHO      TESTUMACRHO
 #    define FORT_ESTDT              ESTMDT 
-#    define FORT_MAXCHANGE          MAXCHANGE
+#    define FORT_MAXCHNG_VELMAG     MAXCHNGVELMAG
 #    define FORT_TRANSVEL           TRANSVEL  
 #    define FORT_ESTATE             ESTATE    
 #    define FORT_ESTATE_FPU         ESTATEFPU
@@ -51,7 +51,7 @@
 #    define FORT_TEST_U_RHO         testurho
 #    define FORT_TEST_UMAC_RHO      testumacrho
 #    define FORT_ESTDT              estmdt
-#    define FORT_MAXCHANGE          maxchange
+#    define FORT_MAXCHNG_VELMAG     maxchngvelmax
 #    define FORT_TRANSVEL           transvel
 #    define FORT_ESTATE             estate
 #    define FORT_ESTATE_FPU         estatefpu
@@ -73,7 +73,7 @@
 #    define FORT_TEST_U_RHO         testurho_
 #    define FORT_TEST_UMAC_RHO      testumacrho_
 #    define FORT_ESTDT              estmdt_
-#    define FORT_MAXCHANGE          maxchange_
+#    define FORT_MAXCHNG_VELMAG     maxchngvelmag_
 #    define FORT_TRANSVEL           transvel_
 #    define FORT_ESTATE             estate_
 #    define FORT_ESTATE_FPU         estatefpu_
@@ -124,7 +124,7 @@ extern "C"
 		   const int* lo, const int* hi, amrex::Real* dt, 
 		   const amrex::Real* dx, amrex::Real* cfl, amrex::Real* u_max);
    
-   void FORT_MAXCHANGE(const amrex::Real* Uodat,  ARLIM_P(uo_lo), ARLIM_P(uo_hi),
+   void FORT_MAXCHNG_VELMAG(const amrex::Real* Uodat,  ARLIM_P(uo_lo), ARLIM_P(uo_hi),
 		   const amrex::Real* Undat,  ARLIM_P(un_lo), ARLIM_P(un_hi),
 		   const int* lo, const int* hi, amrex::Real* max_change);
    

--- a/Source/Godunov.H
+++ b/Source/Godunov.H
@@ -210,6 +210,10 @@ public:      // public access functions
     amrex::Real estdt( amrex::FArrayBox &U, amrex::FArrayBox &tforces, amrex::FArrayBox &Rho,
                 const amrex::Box &grd, const amrex::Real *dx, amrex::Real cfl, amrex::Real *u_max );
 
+	// find the largest change in velocity magnitude since last iteration
+    amrex::Real maxchange( amrex::FArrayBox &U_old, amrex::FArrayBox &U_new, 
+                const amrex::Box &grd );
+
     // test the cell centered Courant number 
     amrex::Real test_u_rho( amrex::FArrayBox &U, amrex::FArrayBox &Rho, const amrex::Box &grd,
                      const amrex::Real *dx, const amrex::Real dt,

--- a/Source/Godunov.H
+++ b/Source/Godunov.H
@@ -211,8 +211,7 @@ public:      // public access functions
                 const amrex::Box &grd, const amrex::Real *dx, amrex::Real cfl, amrex::Real *u_max );
 
 	// find the largest change in velocity magnitude since last iteration
-    amrex::Real maxchange( amrex::FArrayBox &U_old, amrex::FArrayBox &U_new, 
-                const amrex::Box &grd );
+    amrex::Real maxchng_velmag( amrex::FArrayBox &U_old, amrex::FArrayBox &U_new, const amrex::Box &grd );
 
     // test the cell centered Courant number 
     amrex::Real test_u_rho( amrex::FArrayBox &U, amrex::FArrayBox &Rho, const amrex::Box &grd,

--- a/Source/Godunov.cpp
+++ b/Source/Godunov.cpp
@@ -1205,13 +1205,13 @@ Godunov::estdt (FArrayBox&  U,
 }
 
 //
-// Estimate the maximum velocity change since previous iteration. 
+// Estimate the maximum change in velocity magnitude since previous iteration. 
 //
 
 Real
-Godunov::maxchange (FArrayBox&  U_old,
-					FArrayBox&  U_new,
-                	const Box&  grd)
+Godunov::maxchng_velmag (FArrayBox&  U_old,
+						 FArrayBox&  U_new,
+                		 const Box&  grd)
 {
     BL_ASSERT( U_old.nComp()   >= BL_SPACEDIM );
     BL_ASSERT( U_new.nComp()   >= BL_SPACEDIM );
@@ -1225,8 +1225,8 @@ Godunov::maxchange (FArrayBox&  U_old,
     const Real *Uodat = U_old.dataPtr();
     const Real *Undat = U_new.dataPtr();
 
-	Real max_change;
-    FORT_MAXCHANGE(Uodat, ARLIM(uo_lo), ARLIM(uo_hi),
+	Real max_change = 0.0;
+    FORT_MAXCHNG_VELMAG(Uodat, ARLIM(uo_lo), ARLIM(uo_hi),
                	   Undat, ARLIM(un_lo), ARLIM(un_hi),
                	   lo, hi, &max_change);
     return max_change;

--- a/Source/Godunov.cpp
+++ b/Source/Godunov.cpp
@@ -1205,6 +1205,34 @@ Godunov::estdt (FArrayBox&  U,
 }
 
 //
+// Estimate the maximum velocity change since previous iteration. 
+//
+
+Real
+Godunov::maxchange (FArrayBox&  U_old,
+					FArrayBox&  U_new,
+                	const Box&  grd)
+{
+    BL_ASSERT( U_old.nComp()   >= BL_SPACEDIM );
+    BL_ASSERT( U_new.nComp()   >= BL_SPACEDIM );
+
+    const int *lo     = grd.loVect();
+    const int *hi     = grd.hiVect();
+    const int *uo_lo  = U_old.loVect();
+    const int *uo_hi  = U_old.hiVect();
+    const int *un_lo  = U_new.loVect();
+    const int *un_hi  = U_new.hiVect();
+    const Real *Uodat = U_old.dataPtr();
+    const Real *Undat = U_new.dataPtr();
+
+	Real max_change;
+    FORT_MAXCHANGE(Uodat, ARLIM(uo_lo), ARLIM(uo_hi),
+               	   Undat, ARLIM(un_lo), ARLIM(un_hi),
+               	   lo, hi, &max_change);
+    return max_change;
+}
+
+//
 // Estimate the extrema of cell-centered us and rho.
 //
 

--- a/Source/NavierStokesBase.H
+++ b/Source/NavierStokesBase.H
@@ -118,7 +118,7 @@ public:
 	// Check whether simulation has reached steady state, i.e. whether the
 	// change from last iteration is below a prescribed threshold steady_tol. 
     //
-    virtual int steadyState () override;
+    virtual int steadyState ();
     //
     // Build any additional data structures after regrid.
     //
@@ -615,6 +615,7 @@ protected:
     static amrex::Real cfl;           // desired maximum cfl
     static amrex::Real change_max;    // maximum change in dt over a timestep
     static amrex::Real fixed_dt;      // set > 0 to specify dt
+	static bool stop_when_steady; 	  // set to true if simulation should stop at steady-state
 	static amrex::Real steady_tol;    // tolerance for assuming steady-state has been reached
     static int  initial_iter;  // flag for initial pressure iterations
     static int  initial_step;  // flag for initial iterations

--- a/Source/NavierStokesBase.H
+++ b/Source/NavierStokesBase.H
@@ -115,6 +115,11 @@ public:
     //
     virtual int okToContinue () override;
     //
+	// Check whether simulation has reached steady state, i.e. whether the
+	// change from last iteration is below a prescribed threshold steady_tol. 
+    //
+    virtual int steadyState () override;
+    //
     // Build any additional data structures after regrid.
     //
     virtual void post_regrid (int lbase, int new_finest) override;
@@ -610,6 +615,7 @@ protected:
     static amrex::Real cfl;           // desired maximum cfl
     static amrex::Real change_max;    // maximum change in dt over a timestep
     static amrex::Real fixed_dt;      // set > 0 to specify dt
+	static amrex::Real steady_tol;    // tolerance for assuming steady-state has been reached
     static int  initial_iter;  // flag for initial pressure iterations
     static int  initial_step;  // flag for initial iterations
     static amrex::Real dt_cutoff;     // minimum dt allowed

--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -23,6 +23,7 @@ int  NavierStokesBase::init_iter          = 2;
 Real NavierStokesBase::cfl                = 0.8;
 Real NavierStokesBase::change_max         = 1.1;    
 Real NavierStokesBase::fixed_dt           = -1.0;      
+Real NavierStokesBase::steady_tol 		  = 1.0e-10;
 int  NavierStokesBase::initial_iter       = false;  
 int  NavierStokesBase::initial_step       = false;  
 Real NavierStokesBase::dt_cutoff          = 0.0;     
@@ -409,6 +410,7 @@ NavierStokesBase::Initialize ()
     pp.query("dt_cutoff",dt_cutoff);
     pp.query("change_max",change_max);
     pp.query("fixed_dt",fixed_dt);
+    pp.query("steady_tol",steady_tol);
     pp.query("sum_interval",sum_interval);
     pp.query("turb_interval",turb_interval);
     pp.query("jet_interval",jet_interval);
@@ -2339,6 +2341,20 @@ int
 NavierStokesBase::okToContinue ()
 {
     return (level > 0) ? true : (parent->dtLevel(0) > dt_cutoff);
+}
+
+int 
+NavierStokesBase::steadyState()
+{
+	Real 	  max_change = 0.0;
+	MultiFab& U_old 	 = get_old_data(State_Type);
+	MultiFab& U_new  	 = get_new_data(State_Type);
+
+	// change = U_new - U_old
+
+	max_change = max(max_change, change.norm0());
+
+  	return change < steady_tol;
 }
 
 //

--- a/Source/Src_2d/GODUNOV_2D.F
+++ b/Source/Src_2d/GODUNOV_2D.F
@@ -93,10 +93,7 @@ c
      &     lo,hi,max_change)
 c 
 c     ----------------------------------------------------------
-c     estimate the timestep for this grid and scale by CFL number
-c     This routine sets dt as dt = dt_est*cfl where
-c     dt_est is estimated from the actual velocities and their 
-c     total forcing
+c     TODO: Documentation
 c     ----------------------------------------------------------
 c
       implicit none

--- a/Source/Src_2d/GODUNOV_2D.F
+++ b/Source/Src_2d/GODUNOV_2D.F
@@ -87,13 +87,15 @@ c
 
       end
 
-      subroutine FORT_MAXCHANGE (
+      subroutine FORT_MAXCHNG_VELMAG (
      &     old_vel,DIMS(old_vel),
      &     new_vel,DIMS(new_vel),
      &     lo,hi,max_change)
 c 
 c     ----------------------------------------------------------
-c     TODO: Documentation
+c     Given the velocity field at the previous and current time steps
+c     (old_vel and new_vel, respectively), find the largest change in
+c     velocity magnitude between the two.
 c     ----------------------------------------------------------
 c
       implicit none

--- a/Source/Src_2d/GODUNOV_2D.F
+++ b/Source/Src_2d/GODUNOV_2D.F
@@ -87,6 +87,42 @@ c
 
       end
 
+      subroutine FORT_MAXCHANGE (
+     &     old_vel,DIMS(old_vel),
+     &     new_vel,DIMS(new_vel),
+     &     lo,hi,max_change)
+c 
+c     ----------------------------------------------------------
+c     estimate the timestep for this grid and scale by CFL number
+c     This routine sets dt as dt = dt_est*cfl where
+c     dt_est is estimated from the actual velocities and their 
+c     total forcing
+c     ----------------------------------------------------------
+c
+      implicit none
+      REAL_T   old_velmag, new_velmag
+      integer  i, j
+      integer  lo(SDIM), hi(SDIM)
+      REAL_T   max_change
+
+      integer DIMDEC(old_vel)
+      integer DIMDEC(new_vel)
+
+      REAL_T  old_vel(DIMV(old_vel),SDIM)
+      REAL_T  new_vel(DIMV(new_vel),SDIM)
+
+      max_change = zero
+
+      do j = lo(2), hi(2)
+         do i = lo(1), hi(1)
+            old_velmag = sqrt(old_vel(i,j,1)**2 + old_vel(i,j,2)**2)
+            new_velmag = sqrt(new_vel(i,j,1)**2 + new_vel(i,j,2)**2)
+            max_change = max(max_change, abs(new_velmag - old_velmag))
+         end do
+      end do
+
+      end
+
       subroutine FORT_TEST_U_RHO(
      &     u,DIMS(u),
      &     v,DIMS(v),

--- a/Source/Src_3d/GODUNOV_3D.F
+++ b/Source/Src_3d/GODUNOV_3D.F
@@ -94,6 +94,48 @@ c
 
       end
 
+      subroutine FORT_MAXCHANGE (
+     &     old_vel,DIMS(old_vel),
+     &     new_vel,DIMS(new_vel),
+     &     lo,hi,max_change)
+c 
+c     ----------------------------------------------------------
+c     TODO: Documentation
+c     ----------------------------------------------------------
+c
+      implicit none
+      REAL_T   old_velmag, new_velmag
+      integer  i, j, k
+      integer  lo(SDIM), hi(SDIM)
+      REAL_T   max_change
+
+      integer DIMDEC(old_vel)
+      integer DIMDEC(new_vel)
+
+      REAL_T  old_vel(DIMV(old_vel),SDIM)
+      REAL_T  new_vel(DIMV(new_vel),SDIM)
+
+      max_change = zero
+
+!$omp parallel do private(i,j,k,old_velmag,new_velmag)
+!$omp&reduction(max: max_change)
+      do k = lo(3), hi(3)
+          do j = lo(2), hi(2)
+            do i = lo(1), hi(1)
+                old_velmag = sqrt(old_vel(i,j,k,1)**2 +
+     &                            old_vel(i,j,k,2)**2 +
+     &                            old_vel(i,j,k,3)**2)
+                new_velmag = sqrt(new_vel(i,j,k,1)**2 +
+     &                            new_vel(i,j,k,2)**2 +
+     &                            new_vel(i,j,k,3)**2)
+                max_change = max(max_change, abs(new_velmag - old_velmag))
+            end do
+          end do
+      end do
+!$omp end parallel do
+
+      end
+
       subroutine FORT_TEST_U_RHO(
      &     u,DIMS(u),
      &     v,DIMS(v),

--- a/Source/Src_3d/GODUNOV_3D.F
+++ b/Source/Src_3d/GODUNOV_3D.F
@@ -94,13 +94,15 @@ c
 
       end
 
-      subroutine FORT_MAXCHANGE (
+      subroutine FORT_MAXCHNG_VELMAG (
      &     old_vel,DIMS(old_vel),
      &     new_vel,DIMS(new_vel),
      &     lo,hi,max_change)
 c 
 c     ----------------------------------------------------------
-c     TODO: Documentation
+c     Given the velocity field at the previous and current time steps
+c     (old_vel and new_vel, respectively), find the largest change in
+c     velocity magnitude between the two.
 c     ----------------------------------------------------------
 c
       implicit none

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -83,7 +83,8 @@ main (int   argc,
         }
     }
 
-    while ( amrptr->okToContinue()           &&
+    while ( amrptr->okToContinue()                            &&
+		   (amrptr->!steadyState()                            &&
            (amrptr->levelSteps(0) < max_step || max_step < 0) &&
            (amrptr->cumTime() < stop_time || stop_time < 0.0) )
     {

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -84,7 +84,6 @@ main (int   argc,
     }
 
     while ( amrptr->okToContinue()                            &&
-		   (amrptr->!steadyState()                            &&
            (amrptr->levelSteps(0) < max_step || max_step < 0) &&
            (amrptr->cumTime() < stop_time || stop_time < 0.0) )
     {


### PR DESCRIPTION
Added functionality for checking whether steady-state has been reached, and if so, stopping the simulation. This is particularly useful for problems where a steady system is sought, but where one doesn't know beforehand how long time we will require to reach such a state. 

The user activates steady-state checking by setting the input parameter "ns.stop_when_steady" to true (or 1). Additionally, one should set the parameter "ns.steady_tol", which is the accompanying tolerance. If the velocity magnitude changes by less than steady_tol from one iteration to the next, the system is deemed to have reached steady-state. 

Both lid-driven cavity and Poiseuille examples (2D+3D) successfully reach steady-state and consequently stop the simulation. 