### PR TITLE
Remove scaling by dt in constructing RHS of sync diffusion solve.

### DIFF
--- a/Source/Diffusion.cpp
+++ b/Source/Diffusion.cpp
@@ -1323,9 +1323,6 @@ Diffusion::diffuse_Ssync (MultiFab&              Ssync,
 
     MultiFab::Copy(Rhs,Ssync,sigma,0,1,0);
 
-    Rhs.mult(dt);
-
-
     if (verbose > 1)
     {
         MultiFab junk(grids,dmap,1,0,MFInfo(),navier_stokes->Factory());


### PR DESCRIPTION
The RHS is already multiplied by dt in PeleLM mac_sync and diffuse_sync
is only used in PeleLM.