### PR TITLE
Cgilet cc visc

### DIFF
--- a/Source/Diffusion.H
+++ b/Source/Diffusion.H
@@ -219,22 +219,22 @@ public:
                               int                                 rho_comp);
 
 #ifdef AMREX_USE_EB
-    void setBeta(amrex::MLEBABecLap&           op,
-		 const amrex::MultiFab* const* beta,
-		 int                           betaComp);
+    static void setBeta(amrex::MLEBABecLap&           op,
+			const amrex::MultiFab* const* beta,
+			int                           betaComp);
 
     void setViscosity(amrex::MLEBTensorOp&          tensorop,
 		      const amrex::MultiFab* const* beta,
 		      int                           betaComp,
 		      const amrex::MultiFab&        beta_cc);
 #else
-    void setBeta(amrex::MLABecLaplacian&       op,
-		 const amrex::MultiFab* const* beta,
-		 int                           betaComp);
+    static void setBeta(amrex::MLABecLaplacian&       op,
+			const amrex::MultiFab* const* beta,
+			int                           betaComp);
   
-  void setViscosity(amrex::MLTensorOp&            tensorop,
-		    const amrex::MultiFab* const* beta,
-		    int                           betaComp);
+    void setViscosity(amrex::MLTensorOp&            tensorop,
+		      const amrex::MultiFab* const* beta,
+		      int                           betaComp);
 #endif
   
     static void computeExtensiveFluxes(amrex::MLMG&            a_mg,

--- a/Source/Diffusion.H
+++ b/Source/Diffusion.H
@@ -11,19 +11,17 @@
 #include <AMReX_AmrLevel.H>
 #include <AMReX_ErrorList.H>
 #include <AMReX_FluxRegister.H>
-#include <AMReX_ABecLaplacian.H>
 #include <FluxBoxes.H>
-#include <AMReX_MLLinOp.H>
 
-//
-// Include files for tensor solve.
-//
-#include <AMReX_DivVis.H>
-#include <AMReX_LO_BCTYPES.H>
-#include <AMReX_MCMultiGrid.H>
-#include <AMReX_MCCGSolver.H>
-
+#ifdef AMREX_USE_EB
+#include <AMReX_MLEBABecLap.H>
+#include <AMReX_MLEBTensorOp.H>
 #define COVERED_VAL 1.0e40
+#else
+#include <AMReX_MLABecLaplacian.H>
+#include <AMReX_MLTensorOp.H>
+#endif
+
 
 //
 // Useful enumeration of the different forms of the diffusion terms
@@ -92,7 +90,9 @@ public:
 			  int                           rho_flag,
 			  amrex::MultiFab*              delta_rhs, 
 			  const amrex::MultiFab* const* betan, 
-			  const amrex::MultiFab* const* betanp1);
+			  const amrex::MultiFab* const  betanCC, 
+			  const amrex::MultiFab* const* betanp1,
+			  const amrex::MultiFab* const  betanp1CC);
   
     void diffuse_velocity (amrex::Real                   dt,
                            amrex::Real                   be_cn_theta,
@@ -100,8 +100,10 @@ public:
                            int                           rho_flag,
                            amrex::MultiFab*              delta_rhs, 
                            int                           rhsComp,
-                           const amrex::MultiFab* const* betan, 
+                           const amrex::MultiFab* const* betan,
+			   const amrex::MultiFab* const  betanCC, 
                            const amrex::MultiFab* const* betanp1,
+			   const amrex::MultiFab* const  betanp1CC,
                            int                           betaComp);
 
     void diffuse_tensor_velocity (amrex::Real            dt,
@@ -110,8 +112,10 @@ public:
                                   int                    rho_flag,
                                   amrex::MultiFab*       delta_rhs, 
                                   int                    rhsComp,
-                                  const amrex::MultiFab* const* betan, 
+                                  const amrex::MultiFab* const* betan,
+				  const amrex::MultiFab* const  betanCC, 
                                   const amrex::MultiFab* const* betanp1,
+				  const amrex::MultiFab* const  betanp1CC,
                                   int                    betaComp);
 
     void diffuse_Vsync (amrex::MultiFab&              Vsync,
@@ -159,7 +163,8 @@ public:
     void getTensorViscTerms (amrex::MultiFab&              visc_terms, 
                              amrex::Real                   time,
                              const amrex::MultiFab* const* beta,
-			     int                    dataComp);
+			     const amrex::MultiFab* const  betaCC,
+			     int                           dataComp);
 
     void FillBoundary (amrex::BndryRegister& bdry,
                        int                   src_comp,
@@ -212,18 +217,33 @@ public:
                               int                                 rho_flag, 
                               const amrex::MultiFab*              rho,
                               int                                 rho_comp);
-    
-    static amrex::Array<amrex::MultiFab,AMREX_SPACEDIM>
-    computeBeta (const amrex::MultiFab* const* beta,
+
+#ifdef AMREX_USE_EB
+    void setBeta(amrex::MLEBABecLap&           op,
+		 const amrex::MultiFab* const* beta,
 		 int                           betaComp);
 
+    void setViscosity(amrex::MLEBTensorOp&          tensorop,
+		      const amrex::MultiFab* const* beta,
+		      int                           betaComp,
+		      const amrex::MultiFab&        beta_cc);
+#else
+    void setBeta(amrex::MLABecLaplacian&       op,
+		 const amrex::MultiFab* const* beta,
+		 int                           betaComp);
+  
+  void setViscosity(amrex::MLTensorOp&            tensorop,
+		    const amrex::MultiFab* const* beta,
+		    int                           betaComp);
+#endif
+  
     static void computeExtensiveFluxes(amrex::MLMG&            a_mg,
-				amrex::MultiFab&        Soln,
-				amrex::MultiFab* const* flux,
-				const int               fluxComp,
-				const int               nomp,
-				const amrex::Geometry*  a_geom,
-				const amrex::Real       fac );
+				       amrex::MultiFab&        Soln,
+				       amrex::MultiFab* const* flux,
+				       const int               fluxComp,
+				       const int               nomp,
+				       const amrex::Geometry*  a_geom,
+				       const amrex::Real       fac );
 
 protected:
 

--- a/Source/NavierStokes.cpp
+++ b/Source/NavierStokes.cpp
@@ -2498,7 +2498,7 @@ NavierStokes::getDiffusivity (MultiFab* diffusivity[BL_SPACEDIM],
 
     for (int dir = 0; dir < BL_SPACEDIM; dir++)
     {
-      diffusivity[dir]->setVal(visc_coef[diff_comp], dst_comp, 1, diffusivity[dir]->nGrow());
+      diffusivity[dir]->setVal(visc_coef[diff_comp], dst_comp, ncomp, diffusivity[dir]->nGrow());
     }
 }
 

--- a/Source/NavierStokesBase.H
+++ b/Source/NavierStokesBase.H
@@ -418,14 +418,14 @@ protected:
     //
     virtual amrex::Real estTimeStep ();
 
-    virtual void getViscosity (amrex::MultiFab* viscosity[BL_SPACEDIM],
+    virtual void getViscosity (amrex::MultiFab*  viscosity[BL_SPACEDIM],
 			       const amrex::Real time) = 0;
     //
     // Compute viscous terms.
     //
     virtual void getViscTerms (amrex::MultiFab& visc_terms,
-			       int       src_comp,
-			       int       num_comp,
+			       int              src_comp,
+			       int              num_comp,
 			       amrex::Real      time) = 0;
     //
     virtual void mac_sync () = 0;
@@ -595,8 +595,6 @@ protected:
     //
     // arrays for variable viscosity and diffusivity
     //
-    FluxBoxes fb_viscn, fb_viscnp1, fb_diffn, fb_diffnp1;
-    amrex::MultiFab **viscn, **viscnp1, **diffn, **diffnp1;
     amrex::MultiFab *diffn_cc, *diffnp1_cc;
     amrex::MultiFab *viscn_cc, *viscnp1_cc;
     //

--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -277,11 +277,6 @@ NavierStokesBase::NavierStokesBase (Amr&            papa,
     //
     // Allocate the storage for variable viscosity and diffusivity
     //
-    viscn   = fb_viscn.define(this,1,0);
-    viscnp1 = fb_viscnp1.define(this,1,0);
-    diffn   = fb_diffn.define(this,NUM_STATE-Density-1,0);
-    diffnp1 = fb_diffnp1.define(this,NUM_STATE-Density-1,0);
-
     diffn_cc = new MultiFab(grids, dmap, NUM_STATE-Density-1, 1, MFInfo(), Factory());
     diffnp1_cc = new MultiFab(grids, dmap, NUM_STATE-Density-1, 1, MFInfo(), Factory());
     viscn_cc = new MultiFab(grids, dmap, 1, 1, MFInfo(), Factory());
@@ -313,11 +308,6 @@ NavierStokesBase::~NavierStokesBase ()
     // Remove the arrays for variable viscosity and diffusivity
     // and delete the Diffusion object
     //
-    fb_viscn.clear();
-    fb_viscnp1.clear();
-    fb_diffn.clear();
-    fb_diffnp1.clear();
-
     delete viscn_cc;
     delete viscnp1_cc;
     delete diffn_cc;
@@ -2871,11 +2861,6 @@ NavierStokesBase::restart (Amr&          papa,
     //
     // Allocate the storage for variable viscosity and diffusivity
     //
-    viscn   = fb_viscn.define(this,1,0);
-    viscnp1 = fb_viscnp1.define(this,1,0);
-    diffn   = fb_diffn.define(this,NUM_STATE-Density-1,0);
-    diffnp1 = fb_diffnp1.define(this,NUM_STATE-Density-1,0);
-
     diffn_cc = new MultiFab(grids, dmap, NUM_STATE-Density-1, 1, MFInfo(), Factory());
     diffnp1_cc = new MultiFab(grids, dmap, NUM_STATE-Density-1, 1, MFInfo(), Factory());
     viscn_cc = new MultiFab(grids, dmap, 1, 1, MFInfo(), Factory());
@@ -3835,6 +3820,7 @@ NavierStokesBase::velocity_advection_update (Real dt)
         //
         // Average the mac face velocities to get cell centred velocities.
         //
+	//FIXME - need to address this for EB
         FArrayBox Vel(amrex::grow(bx,0),BL_SPACEDIM);
         FORT_AVERAGE_EDGE_STATES(BL_TO_FORTRAN_ANYD(Vel),
                                  BL_TO_FORTRAN_ANYD(u_mac[0][Rhohalf_mfi]),


### PR DESCRIPTION
1. Cell-centroid viscosity is now passed diffuse_tensor_velocity() for use in EB solve
2. Ensures bCoeffs are considered on centroids for EB