### PR TITLE
Fix crash for non-EB.

### DIFF
--- a/Source/NS_getForce.cpp
+++ b/Source/NS_getForce.cpp
@@ -34,24 +34,6 @@ NavierStokesBase::getForce (FArrayBox&       force,
                             const FArrayBox& Scal,
                             int              scalScomp)
 {
-   if (ParallelDescriptor::IOProcessor() && getForceVerbose) {
-      amrex::Print() << "NavierStokesBase::getForce(): Entered..." << std::endl 
-                     << "time      = " << time << std::endl
-                     << "scomp     = " << scomp << std::endl
-                     << "ncomp     = " << ncomp << std::endl
-                     << "ngrow     = " << ngrow << std::endl
-                     << "scalScomp = " << scalScomp << std::endl;
-
-   if (scomp==0)
-       if  (ncomp==3) amrex::Print() << "Doing velocities only" << std::endl;
-       else           amrex::Print() << "Doing all components" << std::endl;
-   else if (scomp==3)
-       if  (ncomp==1) amrex::Print() << "Doing density only" << std::endl;
-       else           amrex::Print() << "Doing all scalars" << std::endl;
-   else if (scomp==4) amrex::Print() << "Doing tracer only" << std::endl;
-   else               amrex::Print() << "Doing individual scalar" << std::endl;
-
-   }
 
    const Real* VelDataPtr  = Vel.dataPtr();
    const Real* ScalDataPtr = Scal.dataPtr(scalScomp);
@@ -67,6 +49,22 @@ NavierStokesBase::getForce (FArrayBox&       force,
    const int   nscal    = NUM_SCALARS;
 
    if (ParallelDescriptor::IOProcessor() && getForceVerbose) {
+      amrex::Print() << "NavierStokesBase::getForce(): Entered..." << std::endl 
+                     << "time      = " << time << std::endl
+                     << "scomp     = " << scomp << std::endl
+                     << "ncomp     = " << ncomp << std::endl
+                     << "ngrow     = " << ngrow << std::endl
+                     << "scalScomp = " << scalScomp << std::endl;
+
+      if (scomp==0)
+	if  (ncomp==3) amrex::Print() << "Doing velocities only" << std::endl;
+	else           amrex::Print() << "Doing all components" << std::endl;
+      else if (scomp==3)
+	if  (ncomp==1) amrex::Print() << "Doing density only" << std::endl;
+	else           amrex::Print() << "Doing all scalars" << std::endl;
+      else if (scomp==4) amrex::Print() << "Doing tracer only" << std::endl;
+      else               amrex::Print() << "Doing individual scalar" << std::endl;
+
 #if (AMREX_SPACEDIM == 3)
       amrex::Print() << "NavierStokesBase::getForce(): Force Domain:" << std::endl;
       amrex::Print() << "(" << f_lo[0] << "," << f_lo[1] << "," << f_lo[2] << ") - "
@@ -152,7 +150,7 @@ NavierStokesBase::getForce (FArrayBox&       force,
       for (int n=0; n<NUM_SCALARS; n++) 
          amrex::Print() << "Scal " << n << " min/max " << scalmin[n] 
                         << " / " << scalmax[n] << std::endl;
-   }
+   } //end if(getForceVerbose)
 
    RealBox gridloc = RealBox(bx,geom.CellSize(),geom.ProbLo());
 

--- a/Source/NavierStokes.cpp
+++ b/Source/NavierStokes.cpp
@@ -540,6 +540,8 @@ NavierStokes::predict_velocity (Real  dt)
             if (getForceVerbose) {
                 Print() << "---\nA - Predict velocity:\n Calling getForce...\n";
             }
+	    const Box& forcebx = grow(bx,1);
+	    tforces.resize(forcebx,AMREX_SPACEDIM);
             getForce(tforces,bx,1,Xvel,BL_SPACEDIM,prev_time,Ufab,Smf[U_mfi],0);
 
             //
@@ -698,6 +700,8 @@ NavierStokes::scalar_advection (Real dt,
                     Print() << "---" << '\n' << "C - scalar advection:" << '\n'
                             << " Calling getForce..." << '\n';
                 }
+		const Box& forcebx = grow(bx,1);
+		tforces.resize(forcebx,num_scalars);
                 getForce(tforces,bx,nGrowF,fscalar,num_scalars,prev_time,Umf[S_mfi],Smf[S_mfi],0);
 
                 for (int d=0; d<BL_SPACEDIM; ++d)

--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -1389,10 +1389,10 @@ NavierStokesBase::estTimeStep ()
        amrex::ParallelFor(bx, [rho, gradp, force] 
        AMREX_GPU_DEVICE(int i, int j, int k) noexcept
        {
-          Real rho_pt = rho(i,j,k);
+          Real rho_inv = 1.0/rho(i,j,k);
           for (int n = 0; n < AMREX_SPACEDIM; n++) {
-             force(i,j,k,n) += gradp(i,j,k,n);
-             force(i,j,k,n) *= rho_pt;
+             force(i,j,k,n) -= gradp(i,j,k,n);
+             force(i,j,k,n) *= rho_inv;
           } 
        });
     }


### PR DESCRIPTION
Recent changes in NSB::getForce were causing non-EB compilations to crash.
This commit fixes the crash, but regression tests for both EB and non-EB problems with non-zero gravity have O(1) differences.