### PR TITLE
Temporary fix for tiling bug in NSB::estTimeStep().

### DIFF
--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -1371,7 +1371,14 @@ NavierStokesBase::estTimeStep ()
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-    for (MFIter mfi(rho_ctime,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    // Disable tiling here for now.
+    // During GPU updates to the following MFIter, a tiling bug was
+    // introduced (for IAMR but not PeleLM) when a temporary force fab
+    // was removed. When getForce() is updated for GPU, it can be 
+    // re-written so the temporary is not needed, and TilingIFNotGPU
+    // will be put back.
+    //    for (MFIter mfi(rho_ctime,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    for (MFIter mfi(rho_ctime,false); mfi.isValid(); ++mfi)
     {
        const auto& bx          = mfi.tilebox();
        const auto  cur_time    = state[State_Type].curTime();


### PR DESCRIPTION
Turn off tiling in offending loop for now. Recent GPU updates
removed a temporary fab still needed in IAMR (but not PLM),
introducing a tiling bug. Once IAMR's getForce is updated,
tiling will be turned back on.

Along with the SyncInterp() fix, this fixes most of the regression tests.  The HotSpot, TaylorGreen and Part-2d tests still show large diffs.