### PR TITLE
Remove a bunch of filling stuff at the bottom of create_umac_grown

### DIFF
--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -1251,41 +1251,8 @@ NavierStokesBase::create_umac_grown (int nGrow)
             u_mac[idim].copy(u_mac_save);
         }
     }
-    //
-    // Now we set the boundary data
-    // FillBoundary fills grow cells that overlap valid regions.
-    // HOEXTRAPTOCC fills outside of domain cells.
-    //
-    const Real* xlo = geom.ProbLo(); //these aren't actually used by the FORT method
-    const Real* dx  = geom.CellSize();
-
-    Box domain_box = geom.Domain();
-    for (int idim = 0; idim < BL_SPACEDIM; ++idim) {
-        if (geom.isPeriodic(idim)) {
-            domain_box.grow(idim,nGrow);
-        }
-    }
-
     for (int n = 0; n < BL_SPACEDIM; ++n)
     {
-        Box dm = domain_box;
-        dm.surroundingNodes(n);
-        const int*  lo  = dm.loVect();
-        const int*  hi  = dm.hiVect();
-
-        //
-        // HOEXTRAPTOCC isn't threaded.  OMP over calls to it.
-        //
-
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-        for (MFIter mfi(u_mac[n]); mfi.isValid(); ++mfi)
-        {
-            FArrayBox& fab = u_mac[n][mfi];
-            amrex_hoextraptocc(BL_TO_FORTRAN_ANYD(fab),lo,hi,dx,xlo);
-        }
-        // call FillBoundary to make sure that fine/fine grow cells are valid
 	u_mac[n].FillBoundary(geom.periodicity());
     }
 }


### PR DESCRIPTION
Don't need all the boundary filling junk that was at the bottom of this function.