### PR TITLE
Revert "Including the cell itself in the non-conservative computation"

### DIFF
--- a/Source/MOL/iamr_mol.cpp
+++ b/Source/MOL/iamr_mol.cpp
@@ -790,7 +790,8 @@ MOL::Redistribute (  Box const& bx, int ncomp,
                 {
                     for (int ii = -1; ii <= 1; ++ii)
                     {
-                        if ( flag(i,j,k).isConnected(ii,jj,kk) and
+                        if ( (ii != 0 or jj != 0 or kk != 0) and
+                             flag(i,j,k).isConnected(ii,jj,kk) and
                              dbox.contains(IntVect(D_DECL(i+ii,j+jj,k+kk))))
                         {
                             Real wted_vf = vfrac(i+ii,j+jj,k+kk) * wgt(i+ii,j+jj,k+kk);


### PR DESCRIPTION
I will revert the changes from this PR. We have decided to go with the version of **not** including the cell itself in the non-conservative computation.