### PR TITLE
Use GpuArray instead of C array

### DIFF
--- a/Source/Godunov/iamr_godunov.cpp
+++ b/Source/Godunov/iamr_godunov.cpp
@@ -197,7 +197,7 @@ Godunov::ComputeFluxes ( Box const& bx,
 
     const auto dx = geom.CellSizeArray();
 
-    Real area[AMREX_SPACEDIM];
+    GpuArray<Real,AMREX_SPACEDIM> area;
 #if ( AMREX_SPACEDIM == 3 )
     area[0] = dx[1]*dx[2];
     area[1] = dx[0]*dx[2];


### PR DESCRIPTION
The array type can be lambda captured to device by recent versions of CUDA.
However, it does not work with HIP and DPC++.  So we switch to GpuArray
instead.