### PR TITLE
[Feature] On-the-fly time-averaging of velocities

### DIFF
--- a/Exec/run2d/inputs.2d.average_hotpost
+++ b/Exec/run2d/inputs.2d.average_hotpost
@@ -10,7 +10,7 @@ ns.temp_cond_coef=1.e-8
 
 # Maximum number of coarse grid timesteps to be taken, if stop_time is
 #  not reached first.
-max_step 		= 0
+max_step 		= 30
 
 # Time at which calculation stops, if max_step is not reached first.
 stop_time 		= 1.0

--- a/Exec/run2d/inputs.2d.average_hotpost
+++ b/Exec/run2d/inputs.2d.average_hotpost
@@ -1,0 +1,132 @@
+
+#*******************************************************************************
+# INPUTS.2D.HOTSPOT
+#*******************************************************************************
+
+ns.do_temp=1
+ns.temp_cond_coef=1.e-8
+
+#NOTE: You may set *either* max_step or stop_time, or you may set them both.
+
+# Maximum number of coarse grid timesteps to be taken, if stop_time is
+#  not reached first.
+max_step 		= 0
+
+# Time at which calculation stops, if max_step is not reached first.
+stop_time 		= 1.0
+
+# What to use for the refinement criterion
+ns.do_tracer_ref = 0
+ns.do_density_ref = 0
+ns.do_vorticity_ref = 0
+ns.do_temp_ref = 1
+
+#*******************************************************************************
+
+# Number of cells in each coordinate direction at the coarsest level
+amr.n_cell 		= 32 32
+amr.max_grid_size	= 32
+
+#*******************************************************************************
+
+# Maximum level (defaults to 0 for single level calculation)
+amr.max_level		= 1 # maximum number of levels of refinement
+
+#*******************************************************************************
+
+# Interval (in number of level l timesteps) between regridding
+amr.regrid_int		= 2
+
+#*******************************************************************************
+
+# Refinement ratio as a function of level
+amr.ref_ratio		= 2 2 2 2
+
+#*******************************************************************************
+
+# Sets the "NavierStokes" code to be verbose
+ns.v                    = 1
+
+#*******************************************************************************
+
+# Sets the "amr" code to be verbose
+amr.v                   = 1
+
+#*******************************************************************************
+
+# Interval (in number of coarse timesteps) between checkpoint(restart) files
+amr.check_int		= 1 
+
+#*******************************************************************************
+
+# Interval (in number of coarse timesteps) between plot files
+amr.plot_int		= 1
+
+#*******************************************************************************
+
+# CFL number to be used in calculating the time step : dt = dx / max(velocity)
+ns.cfl                  = 0.9  # CFL number used to set dt
+
+#*******************************************************************************
+
+# Factor by which the first time is shrunk relative to CFL constraint
+ns.init_shrink          = 0.3  # factor which multiplies the very first time step
+
+#*******************************************************************************
+
+# Viscosity coefficient 
+ns.vel_visc_coef        = 0.001
+
+#*******************************************************************************
+
+# Diffusion coefficient for first scalar
+ns.scal_diff_coefs      = 0.001
+
+#*******************************************************************************
+
+# Forcing term defaults to  rho * abs(gravity) "down"
+ns.gravity              = -9.8
+
+#*******************************************************************************
+
+# Name of the file which specifies problem-specific parameters (defaults to "probin")
+amr.probin_file 	= probin.2d.hotspot
+
+#*******************************************************************************
+
+# Set to 0 if x-y coordinate system, set to 1 if r-z.
+geometry.coord_sys   =  0
+
+#*******************************************************************************
+
+# Physical dimensions of the low end of the domain.
+geometry.prob_lo     =  -1. 0. 
+
+# Physical dimensions of the high end of the domain.
+geometry.prob_hi     =  1. 2. 
+
+#*******************************************************************************
+
+#Set to 1 if periodic in that direction
+geometry.is_periodic =  0 0
+
+#*******************************************************************************
+
+# Boundary conditions on the low end of the domain.
+ns.lo_bc             = 4 4  
+
+# Boundary conditions on the high end of the domain.
+ns.hi_bc             = 4 4  
+
+# 0 = Interior/Periodic  3 = Symmetry
+# 1 = Inflow             4 = SlipWall
+# 2 = Outflow            5 = NoSlipWall
+
+#*******************************************************************************
+
+# Add vorticity to the variables in the plot files.
+amr.derive_plot_vars    = mag_vort   diveru   avg_pressure velocity_average
+amr.plot_vars = x_velocity y_velocity density tracer temp
+#*******************************************************************************
+
+ns.avg_interval = 1

--- a/Exec/square_grid_turbulence/inputs.3d.square_grid
+++ b/Exec/square_grid_turbulence/inputs.3d.square_grid
@@ -1,7 +1,7 @@
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #            SIMULATION STOP            #
 #.......................................#
-stop_time               =   10.2         # Max (simulated) time to evolve
+stop_time               =   100.2         # Max (simulated) time to evolve
 max_step                =  -1           # Max number of time steps
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #           SOLVER SETTINGS             #
@@ -21,7 +21,7 @@ ns.cfl               = 0.7
 amr.plot_int            =   20          # Steps between plot files
 amr.plot_per            =   0.1         # Steps between plot files
 amr.check_int           =   100        # Steps between checkpoint files
-amr.restart             =   chk00300          # Checkpoint to restart from
+#amr.restart             =   chk13100          # Checkpoint to restart from
 amr.probin_file         = probin.3d.square_grid
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #               PHYSICS                 #
@@ -32,13 +32,13 @@ ns.scal_diff_coefs       = 1.0
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #        ADAPTIVE MESH REFINEMENT       #
 #.......................................#
-amr.n_cell              =   128 32 32    # Grid cells at coarsest AMRlevel
-amr.max_level           =   2           # Max AMR level in hierarchy
+amr.n_cell              =   512 128 128
+amr.max_level           =   0           # Max AMR level in hierarchy
 amr.grid_eff            =   0.7
 amr.n_error_buf         =   2 2 2 2 2
 amr.regrid_int      = 2       # how often to regrid
 amr.blocking_factor = 8      # block factor in grid generation
-amr.max_grid_size   = 64
+#amr.max_grid_size   = 64
 
 ns.do_vorticity_ref = 1
 
@@ -63,12 +63,16 @@ square_grid.dim_L0 = 0.1
 square_grid.ratio_t0_L0_cross = 1.886792452830189e-01
 square_grid.ratio_t0_stream_thickness = 0.25
 
-amr.derive_plot_vars = mag_vort avg_pressure gradpx gradpy gradpz
+amr.derive_plot_vars    = mag_vort avg_pressure velocity_average
+amr.plot_vars = x_velocity y_velocity 
+#*******************************************************************************
+
+ns.avg_interval = 0
 
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #              VERBOSITY                #
 #.......................................#
-ns.v                    = 1 # NS solver
+ns.v                    = 10 # NS solver
 proj.v                  = 1 # Nodal projection
 mac_proj.verbose        = 0 # MacProjector
 #diffusion.verbose      = 1 # Diffusion operator

--- a/Source/Make.package
+++ b/Source/Make.package
@@ -11,6 +11,9 @@ ifneq ($(SKIP_NS_SPECIFIC_CODE), TRUE)
   CEXE_sources += NS_error.cpp NS_setup.cpp NSBld.cpp NavierStokes.cpp
   CEXE_headers += NavierStokes.H
 
+  CEXE_sources += NS_derive.cpp NS_average.cpp
+  CEXE_headers += NS_derive.H
+
 endif
 
 CEXE_sources += NS_getForce.cpp

--- a/Source/NS_BC.H
+++ b/Source/NS_BC.H
@@ -38,6 +38,11 @@ static int dsdt_bc[] =
     INT_DIR, EXT_DIR, EXT_DIR, REFLECT_EVEN, REFLECT_EVEN, REFLECT_EVEN
 };
 
+static int average_bc[] =
+{
+    INT_DIR, INT_DIR, INT_DIR, INT_DIR,      INT_DIR,      INT_DIR
+};
+
 static RegType project_bc [] =
 {
     interior, inflow, outflow, refWall, refWall, refWall

--- a/Source/NS_average.cpp
+++ b/Source/NS_average.cpp
@@ -10,7 +10,17 @@
 
 using namespace amrex;
 
-
+//--------------------------------------------------------------------
+// "On the fly" time averaging of the velocity
+//
+//  Just put ns.avg_interval = something (>0) to activate the feature.
+//  avg_interval controls the interval of time-steps when a solution is taken into account.
+//  The average is dumped in each plotfile.
+//
+//  Do not forget to add "velocity_average" in amr.derive_plot_vars.
+//  The averaging process starts from the initial/restart solution,
+//  this means that the averaging from previous runs are forgotten.
+//---------------------------------------------------------------------
 
 void
 NavierStokesBase::time_average(bool flag_init, amrex::Real&  time_avg, amrex::Real&  dt_avg, const Real& dt_level)

--- a/Source/NS_average.cpp
+++ b/Source/NS_average.cpp
@@ -25,6 +25,22 @@ NavierStokesBase::time_average(bool flag_init, amrex::Real&  time_avg, amrex::Re
 
 {
 
+   MultiFab& Savg   = get_new_data(Average_Type);
+      MultiFab& Savg_old   = get_old_data(Average_Type);
+
+
+      amrex::Print() << std::endl << " DEBUG S_OLD " << std::endl;
+      for (MFIter mfi(Savg_old,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+      {
+      amrex::Print() << Savg_old[mfi];
+      }
+amrex::Print() << std::endl << " DEBUG S_NEW " << std::endl;
+      for (MFIter mfi(Savg,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+      {
+      amrex::Print() << Savg[mfi];
+      }
+
+
   if (flag_init)
   {
 

--- a/Source/NS_average.cpp
+++ b/Source/NS_average.cpp
@@ -50,10 +50,10 @@ NavierStokesBase::time_average(bool flag_init, amrex::Real&  time_avg, amrex::Re
        amrex::ParallelFor(bx, BL_SPACEDIM, [S_state, S_avg, S_avg_old]
        AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
        {
-          S_avg(i,j,k,n) = S_state(i,j,k,n);
-          S_avg(i,j,k,n+BL_SPACEDIM) = S_state(i,j,k,n) * S_state(i,j,k,n);
-          S_avg_old(i,j,k,n) = S_avg(i,j,k,n);
-          S_avg_old(i,j,k,n+BL_SPACEDIM) = S_avg(i,j,k,n+BL_SPACEDIM);
+          S_avg(i,j,k,n) = 0.; //S_state(i,j,k,n);
+          S_avg(i,j,k,n+BL_SPACEDIM) = 0.; //S_state(i,j,k,n) * S_state(i,j,k,n);
+          S_avg_old(i,j,k,n) = 0.; //S_avg(i,j,k,n);
+          S_avg_old(i,j,k,n+BL_SPACEDIM) = 0.; //S_avg(i,j,k,n+BL_SPACEDIM);
        });
     }
 
@@ -82,8 +82,8 @@ NavierStokesBase::time_average(bool flag_init, amrex::Real&  time_avg, amrex::Re
          amrex::ParallelFor(bx, BL_SPACEDIM, [S_state, S_avg, S_avg_old, dt_avg]
          AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
          {
-            S_avg(i,j,k,n) = S_avg(i,j,k,n) + dt_avg * S_state(i,j,k,n);
-            S_avg(i,j,k,n+BL_SPACEDIM) = S_avg(i,j,k,n+BL_SPACEDIM) + dt_avg * S_state(i,j,k,n) * S_state(i,j,k,n);
+            S_avg(i,j,k,n) = S_avg_old(i,j,k,n) + dt_avg * S_state(i,j,k,n);
+            S_avg(i,j,k,n+BL_SPACEDIM) = S_avg_old(i,j,k,n+BL_SPACEDIM) + dt_avg * S_state(i,j,k,n) * S_state(i,j,k,n);
             S_avg_old(i,j,k,n) = S_avg(i,j,k,n);
             S_avg_old(i,j,k,n+BL_SPACEDIM) = S_avg(i,j,k,n+BL_SPACEDIM);
          });

--- a/Source/NS_average.cpp
+++ b/Source/NS_average.cpp
@@ -30,46 +30,6 @@ NavierStokesBase::time_average(bool flag_init, amrex::Real&  time_avg, amrex::Re
 
     dt_avg   = 0;
     time_avg = 0;
-/*
-    MultiFab& Sstate = get_new_data(State_Type);
-    MultiFab& Savg   = get_new_data(Average_Type);
-    MultiFab& Savg_old   = get_old_data(Average_Type);
-
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif  
-    for (MFIter mfi(Savg,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-    {
-       const Box& bx = mfi.tilebox();
-       auto const& S_state = Sstate.array(mfi,Xvel);
-       auto const& S_avg   = Savg.array(mfi);
-       auto const& S_avg_old   = Savg_old.array(mfi);
-
-       amrex::ParallelFor(bx, BL_SPACEDIM, [S_state, S_avg, S_avg_old]
-       AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
-       {
-          S_avg(i,j,k,n) = 0.; //S_state(i,j,k,n);
-          S_avg(i,j,k,n+BL_SPACEDIM) = 0.; //S_state(i,j,k,n) * S_state(i,j,k,n);
-          S_avg_old(i,j,k,n) = 0.; //S_avg(i,j,k,n);
-          S_avg_old(i,j,k,n+BL_SPACEDIM) = 0.; //S_avg(i,j,k,n+BL_SPACEDIM);
-       });
-    }
-*/
-
-      MultiFab& Savg   = get_new_data(Average_Type);
-      MultiFab& Savg_old   = get_old_data(Average_Type);
-
-
-      amrex::Print() << std::endl << " DEBUG S_OLD " << std::endl;
-      for (MFIter mfi(Savg_old,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-      {
-      amrex::Print() << Savg_old[mfi];
-      }
-amrex::Print() << std::endl << " DEBUG S_NEW " << std::endl;
-      for (MFIter mfi(Savg,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-      {
-      amrex::Print() << Savg[mfi];
-      }
 
   }
   else
@@ -83,34 +43,6 @@ amrex::Print() << std::endl << " DEBUG S_NEW " << std::endl;
       MultiFab& Savg   = get_new_data(Average_Type); 
       MultiFab& Savg_old   = get_old_data(Average_Type);
 
-/*
-MultiFab& Stest   = get_old_data(Average_Type);
-Stest.setVal(0.);
-FillPatchIterator U_fpi(*this,Stest,0,state[Average_Type].curTime(),Average_Type,Xvel,BL_SPACEDIM*2);
-    MultiFab& Umf=U_fpi.get_mf();
-if (level > 0){
-
-amrex::Print() << std::endl << " DEBUG TEST NEW " << std::endl;
-      for (MFIter mfi(Umf,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-      {
-      amrex::Print() << Umf[mfi];
-      }
-}
-*/
-
-
-      amrex::Print() << std::endl << " DEBUG S_OLD " << std::endl;
-      for (MFIter mfi(Savg_old,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-      {
-      amrex::Print() << Savg_old[mfi];
-      }
-amrex::Print() << std::endl << " DEBUG S_NEW " << std::endl;
-      for (MFIter mfi(Savg,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-      {
-      amrex::Print() << Savg[mfi];
-      }
-
-
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
@@ -120,10 +52,6 @@ amrex::Print() << std::endl << " DEBUG S_NEW " << std::endl;
          auto const& S_state = Sstate.array(mfi,Xvel);
          auto const& S_avg   = Savg.array(mfi);
          auto const& S_avg_old   = Savg_old.array(mfi);
-
-  //    amrex::Print() << std::endl << " DEBUG S_OLD " << std::endl;
-  //    amrex::Print() << Savg_old[mfi];
-
 
          amrex::ParallelFor(bx, BL_SPACEDIM, [S_state, S_avg, S_avg_old, dt_avg]
          AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
@@ -141,7 +69,6 @@ amrex::Print() << std::endl << " DEBUG S_NEW " << std::endl;
     }
 
   }
-  
 
 }
 

--- a/Source/NS_average.cpp
+++ b/Source/NS_average.cpp
@@ -17,59 +17,47 @@ NavierStokesBase::time_average(bool flag_init, amrex::Real&  time_avg, amrex::Re
 
 {
 
-  if (ParallelDescriptor::IOProcessor() ) {
-    amrex::Print() << "\n  WE ARE IN THE NEW ROUTINE FOR TIME AVERAGE \n\n";
-  }
-
   if (flag_init)
   {
 
     dt_avg   = 0;
     time_avg = 0;
 
-    amrex::Print() << " " << std::endl;
-    amrex::Print() << "DEBUG AVEGRAGE after INIT dt_avg = " << dt_avg << std::endl;
-    amrex::Print() << "DEBUG AVEGRAGE after INIT time_avg = " << time_avg << std::endl;
-
-
-MultiFab& Sstate = get_new_data(State_Type);
-     MultiFab& Savg   = get_new_data(Average_Type);
+    MultiFab& Sstate = get_new_data(State_Type);
+    MultiFab& Savg   = get_new_data(Average_Type);
+    MultiFab& Savg_old   = get_old_data(Average_Type);
 
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif  
-      for (MFIter mfi(Savg,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-      {
-         const Box& bx = mfi.tilebox();
-         auto const& S_state = Sstate.array(mfi,Xvel);
-         auto const& S_avg   = Savg.array(mfi);
+    for (MFIter mfi(Savg,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+       const Box& bx = mfi.tilebox();
+       auto const& S_state = Sstate.array(mfi,Xvel);
+       auto const& S_avg   = Savg.array(mfi);
+       auto const& S_avg_old   = Savg_old.array(mfi);
 
-         amrex::ParallelFor(bx, BL_SPACEDIM, [S_state, S_avg, dt_avg]
-         AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
-         {
-            S_avg(i,j,k,n) = S_state(i,j,k,n);
-         });
-      }
-
+       amrex::ParallelFor(bx, BL_SPACEDIM, [S_state, S_avg, S_avg_old]
+       AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+       {
+          S_avg(i,j,k,n) = S_state(i,j,k,n);
+          S_avg(i,j,k,n+BL_SPACEDIM) = S_state(i,j,k,n) * S_state(i,j,k,n);
+          S_avg_old(i,j,k,n) = S_avg(i,j,k,n);
+          S_avg_old(i,j,k,n+BL_SPACEDIM) = S_avg(i,j,k,n+BL_SPACEDIM);
+       });
+    }
 
   }
   else
   {
 
-    amrex::Print() << " " << std::endl;
-    amrex::Print() << "DEBUG AVEGRAGE dt_level = " << dt_level << std::endl;
-    amrex::Print() << "DEBUG AVEGRAGE before dt_avg = " << dt_avg << std::endl;
-
     dt_avg = dt_avg + dt_level;
-    amrex::Print() << "DEBUG AVEGRAGE after dt_avg = " << dt_avg << std::endl;
 
-    int avg_interval = 1;
     if (parent->levelSteps(0)%avg_interval == 0)
     {
-      amrex::Print() << "DEBUG HELLO FROM MODULO " << std::endl;
- 
-     MultiFab& Sstate = get_new_data(State_Type);
-     MultiFab& Savg   = get_new_data(Average_Type); 
+      MultiFab& Sstate = get_new_data(State_Type);
+      MultiFab& Savg   = get_new_data(Average_Type); 
+      MultiFab& Savg_old   = get_old_data(Average_Type);
 
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
@@ -79,167 +67,25 @@ MultiFab& Sstate = get_new_data(State_Type);
          const Box& bx = mfi.tilebox();
          auto const& S_state = Sstate.array(mfi,Xvel);
          auto const& S_avg   = Savg.array(mfi);
+         auto const& S_avg_old   = Savg_old.array(mfi);
 
-         amrex::ParallelFor(bx, BL_SPACEDIM, [S_state, S_avg, dt_avg]
+         amrex::ParallelFor(bx, BL_SPACEDIM, [S_state, S_avg, S_avg_old, dt_avg]
          AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
          {
             S_avg(i,j,k,n) = S_avg(i,j,k,n) + dt_avg * S_state(i,j,k,n);
+            S_avg(i,j,k,n+BL_SPACEDIM) = S_avg(i,j,k,n+BL_SPACEDIM) + dt_avg * S_state(i,j,k,n) * S_state(i,j,k,n);
+            S_avg_old(i,j,k,n) = S_avg(i,j,k,n);
+            S_avg_old(i,j,k,n+BL_SPACEDIM) = S_avg(i,j,k,n+BL_SPACEDIM);
          });
       }
-   
 
-  //      for (MFIter mfi(Savg,true); mfi.isValid(); ++mfi)
-  //      {
-  //       amrex::Print() << Savg[mfi];
-  //      }
- 
+      time_avg = time_avg + dt_avg;
+      dt_avg = 0;
+
     }
-
 
   }
   
 
-/*  
- 
-  //
-  // We get the state data at the current time in order to get the velocity
-  //
-  
-  auto whichTime = which_time(State_Type,time);
-  BL_ASSERT(whichTime == AmrOldTime || whichTime == AmrNewTime);
-
-  MultiFab& Sstate = (whichTime == AmrOldTime) ? get_old_data(State_Type) : get_new_data(State_Type);
-  
-  int nGrow = 1;
-  FillPatchIterator fpi(*this,Sstate,nGrow,time,State_Type,Xvel,AMREX_SPACEDIM);
-  MultiFab& Uvel=fpi.get_mf();
-  //
-  // Now that we have the gradients of velocity, we can compute the LES subgrid viscosity
-  // 
-      
-  const auto dx = geom.CellSizeArray();
-
-  FArrayBox fab_tmp;
-  for (MFIter mfi(Uvel,true); mfi.isValid(); ++mfi)
-  {
-    Box bx = mfi.tilebox();
-
-    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-  
-      const Box& nbx = mfi.nodaltilebox(idim);
-      Array4<Real      > dst = mu_LES[idim]->array(mfi);
-      Array4<Real      > src = grad_Uvel[idim]->array(mfi);
-
-      Real Cs_cst = LES_model == "Smagorinsky" ? smago_Cs_cst : sigma_Cs_cst;
-      
-      if (LES_model == "Smagorinsky") {
-	
-	if (ParallelDescriptor::IOProcessor() && getLESVerbose) {               
-	  amrex::Print() << "\n in calc_mut_LES : WE DO SMAGORNISKY with constant " << Cs_cst << "\n\n";
-	}
-
-	AMREX_HOST_DEVICE_PARALLEL_FOR_4D (nbx, 1, i, j, k, n,
-	{
-
-            Real smag = 0;
-            for (int i_symij = 0; i_symij < dim_fluxes; ++i_symij)
-            {
-              Real symij = src(i,j,k,i_symij) + src(i,j,k,i_symij);
-              smag += symij * symij;
-            }
-                  
-            smag = 0.5 * smag;
-                  
-            dst(i,j,k,n) = pow(Cs_cst * dx[idim],2) * sqrt(smag);
-                    
-	});
-      } else if (LES_model == "Sigma") {
-
-         //  Reference for the Sigma model
-         //          Franck Nicoud, Hubert Baya Toda, Olivier Cabrit, Sanjeeb Bose, Jungil Lee
-         //          Using singular values to build a subgrid-scale model for large eddy simulations
-         //          Physics of Fluids, American Institute of Physics, 2011, 23 (8), pp.085106. ⟨10.1063/1.3623274⟩
-         //          DOI : 10.1063/1.3623274
-
-
-#if (AMREX_SPACEDIM < 3)
-	amrex::Abort("FATAL ERROR in NS_LES.cpp: Sigma model is only for 3D");
-#endif
-
-	AMREX_HOST_DEVICE_PARALLEL_FOR_4D (nbx, 1, i, j, k, n,
-        {
-
-           Real G_11 = src(i,j,k,0)*src(i,j,k,0)  + src(i,j,k,1)*src(i,j,k,1)  +  src(i,j,k,2)*src(i,j,k,2);
-           Real G_12 = src(i,j,k,0)*src(i,j,k,3)  + src(i,j,k,1)*src(i,j,k,4)  +  src(i,j,k,2)*src(i,j,k,5);
-           Real G_13 = src(i,j,k,0)*src(i,j,k,6)  + src(i,j,k,1)*src(i,j,k,7)  +  src(i,j,k,2)*src(i,j,k,8);
-           Real G_22 = src(i,j,k,3)*src(i,j,k,3)  + src(i,j,k,4)*src(i,j,k,4)  +  src(i,j,k,5)*src(i,j,k,5);
-           Real G_23 = src(i,j,k,3)*src(i,j,k,6)  + src(i,j,k,4)*src(i,j,k,7)  +  src(i,j,k,5)*src(i,j,k,8);
-           Real G_33 = src(i,j,k,6)*src(i,j,k,6)  + src(i,j,k,7)*src(i,j,k,7)  +  src(i,j,k,8)*src(i,j,k,8);
-
-           //     First invariant (trace)
-           Real I1 = G_11 + G_22 + G_33;
- 
-           //     Second invariant (0.5 * (tr(G)^2 - tr(G^2))
-           Real I2 = G_11*G_22 - pow(G_12,2) + G_22*G_33 - pow(G_23,2) + G_11*G_33 - pow(G_13,2);
-
-           //     Third invariant (determinant)
-           Real I3 = G_11*(G_22*G_33 - G_23*G_23) - G_12*(G_33*G_12 - G_13*G_23) + G_13*(G_12*G_23 - G_13*G_22);
-
-           //     Rotation angles
-           Real alpha1 = max(0.,pow(I1/3,2) - I2/3);
-
-           if ( alpha1 == 0. ){
-
-              dst(i,j,k,n) = 0.;
-
-           }
-           else
-           {
-
-              Real alpha2 = pow(I1/3,3) -I1*I2/6 + I3/2;
-
-              Real alphaArg = (alpha2*sqrt(1/alpha1))/alpha1;
-
-              // Keeping AlphaArg between -1 and 1
-
-              if ( alphaArg > 1. ){
-                alphaArg = 1.;
-              }
-              else if ( alphaArg < -1. ){
-                alphaArg = -1.;
-              }
-              Real alpha3 = acos(alphaArg)/3;
-
-              //       Singular values
-              
-              // Ensuring that sigma1 >= sigma 2 >= sigma3 >=0 so that mu_LES is positive
-
-              Real sigma1 = sqrt(max(0. ,I1/3 + 2 * sqrt(alpha1) * cos(alpha3)));
-              Real sigma2 = sqrt(max(0. ,I1/3 - 2 * sqrt(alpha1) * cos(M_PI/3 + alpha3)));
-              Real sigma3 = sqrt(max(0. ,I1/3 - 2 * sqrt(alpha1) * cos(M_PI/3 - alpha3)));
- 
-              Real verysmall = 1.e-24;
-              sigma2 = max(sigma3,sigma2);
-              sigma1 = max(sigma2,sigma1);
-              sigma1 = max(verysmall,sigma1);
-
-
-	      //       Compute the sigma operator
-              dst(i,j,k,n) = pow(Cs_cst * dx[idim],2) * ((sigma3 * (sigma1-sigma2) * (sigma2-sigma3)) / pow(sigma1,2));
-
-           }
-	});
-
-      } else {
-
-	amrex::Abort("\n DEBUG DONT KNOW THIS LES MODEL \n\n");
-
-      }
-                    
-    }
-    
-  }
-
-  */
 }
 

--- a/Source/NS_average.cpp
+++ b/Source/NS_average.cpp
@@ -1,0 +1,175 @@
+//fixme, for writesingle level plotfile
+#include<AMReX_PlotFileUtil.H>
+//
+
+#include <NavierStokesBase.H>
+#include <AMReX_VisMF.H>
+
+
+
+using namespace amrex;
+
+
+
+void
+NavierStokesBase::time_average(int flag_init, amrex::Real&  dt_avg, const Real& dt_level)
+
+{
+
+  if (ParallelDescriptor::IOProcessor() ) {
+    amrex::Print() << "\n  WE ARE IN THE NEW ROUTINE FOR TIME AVERAGE \n\n";
+  }
+
+  amrex::Print() << " " << std::endl;
+  amrex::Print() << "DEBUG AVEGRAGE dt_level = " << dt_level << std::endl;
+ amrex::Print() << "DEBUG AVEGRAGE before dt_avg = " << dt_avg << std::endl;
+
+  dt_avg = dt_avg + dt_level;
+   amrex::Print() << "DEBUG AVEGRAGE after dt_avg = " << dt_avg << std::endl;
+
+  
+
+/*  
+ 
+  //
+  // We get the state data at the current time in order to get the velocity
+  //
+  
+  auto whichTime = which_time(State_Type,time);
+  BL_ASSERT(whichTime == AmrOldTime || whichTime == AmrNewTime);
+
+  MultiFab& Sstate = (whichTime == AmrOldTime) ? get_old_data(State_Type) : get_new_data(State_Type);
+  
+  int nGrow = 1;
+  FillPatchIterator fpi(*this,Sstate,nGrow,time,State_Type,Xvel,AMREX_SPACEDIM);
+  MultiFab& Uvel=fpi.get_mf();
+  //
+  // Now that we have the gradients of velocity, we can compute the LES subgrid viscosity
+  // 
+      
+  const auto dx = geom.CellSizeArray();
+
+  FArrayBox fab_tmp;
+  for (MFIter mfi(Uvel,true); mfi.isValid(); ++mfi)
+  {
+    Box bx = mfi.tilebox();
+
+    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+  
+      const Box& nbx = mfi.nodaltilebox(idim);
+      Array4<Real      > dst = mu_LES[idim]->array(mfi);
+      Array4<Real      > src = grad_Uvel[idim]->array(mfi);
+
+      Real Cs_cst = LES_model == "Smagorinsky" ? smago_Cs_cst : sigma_Cs_cst;
+      
+      if (LES_model == "Smagorinsky") {
+	
+	if (ParallelDescriptor::IOProcessor() && getLESVerbose) {               
+	  amrex::Print() << "\n in calc_mut_LES : WE DO SMAGORNISKY with constant " << Cs_cst << "\n\n";
+	}
+
+	AMREX_HOST_DEVICE_PARALLEL_FOR_4D (nbx, 1, i, j, k, n,
+	{
+
+            Real smag = 0;
+            for (int i_symij = 0; i_symij < dim_fluxes; ++i_symij)
+            {
+              Real symij = src(i,j,k,i_symij) + src(i,j,k,i_symij);
+              smag += symij * symij;
+            }
+                  
+            smag = 0.5 * smag;
+                  
+            dst(i,j,k,n) = pow(Cs_cst * dx[idim],2) * sqrt(smag);
+                    
+	});
+      } else if (LES_model == "Sigma") {
+
+         //  Reference for the Sigma model
+         //          Franck Nicoud, Hubert Baya Toda, Olivier Cabrit, Sanjeeb Bose, Jungil Lee
+         //          Using singular values to build a subgrid-scale model for large eddy simulations
+         //          Physics of Fluids, American Institute of Physics, 2011, 23 (8), pp.085106. ⟨10.1063/1.3623274⟩
+         //          DOI : 10.1063/1.3623274
+
+
+#if (AMREX_SPACEDIM < 3)
+	amrex::Abort("FATAL ERROR in NS_LES.cpp: Sigma model is only for 3D");
+#endif
+
+	AMREX_HOST_DEVICE_PARALLEL_FOR_4D (nbx, 1, i, j, k, n,
+        {
+
+           Real G_11 = src(i,j,k,0)*src(i,j,k,0)  + src(i,j,k,1)*src(i,j,k,1)  +  src(i,j,k,2)*src(i,j,k,2);
+           Real G_12 = src(i,j,k,0)*src(i,j,k,3)  + src(i,j,k,1)*src(i,j,k,4)  +  src(i,j,k,2)*src(i,j,k,5);
+           Real G_13 = src(i,j,k,0)*src(i,j,k,6)  + src(i,j,k,1)*src(i,j,k,7)  +  src(i,j,k,2)*src(i,j,k,8);
+           Real G_22 = src(i,j,k,3)*src(i,j,k,3)  + src(i,j,k,4)*src(i,j,k,4)  +  src(i,j,k,5)*src(i,j,k,5);
+           Real G_23 = src(i,j,k,3)*src(i,j,k,6)  + src(i,j,k,4)*src(i,j,k,7)  +  src(i,j,k,5)*src(i,j,k,8);
+           Real G_33 = src(i,j,k,6)*src(i,j,k,6)  + src(i,j,k,7)*src(i,j,k,7)  +  src(i,j,k,8)*src(i,j,k,8);
+
+           //     First invariant (trace)
+           Real I1 = G_11 + G_22 + G_33;
+ 
+           //     Second invariant (0.5 * (tr(G)^2 - tr(G^2))
+           Real I2 = G_11*G_22 - pow(G_12,2) + G_22*G_33 - pow(G_23,2) + G_11*G_33 - pow(G_13,2);
+
+           //     Third invariant (determinant)
+           Real I3 = G_11*(G_22*G_33 - G_23*G_23) - G_12*(G_33*G_12 - G_13*G_23) + G_13*(G_12*G_23 - G_13*G_22);
+
+           //     Rotation angles
+           Real alpha1 = max(0.,pow(I1/3,2) - I2/3);
+
+           if ( alpha1 == 0. ){
+
+              dst(i,j,k,n) = 0.;
+
+           }
+           else
+           {
+
+              Real alpha2 = pow(I1/3,3) -I1*I2/6 + I3/2;
+
+              Real alphaArg = (alpha2*sqrt(1/alpha1))/alpha1;
+
+              // Keeping AlphaArg between -1 and 1
+
+              if ( alphaArg > 1. ){
+                alphaArg = 1.;
+              }
+              else if ( alphaArg < -1. ){
+                alphaArg = -1.;
+              }
+              Real alpha3 = acos(alphaArg)/3;
+
+              //       Singular values
+              
+              // Ensuring that sigma1 >= sigma 2 >= sigma3 >=0 so that mu_LES is positive
+
+              Real sigma1 = sqrt(max(0. ,I1/3 + 2 * sqrt(alpha1) * cos(alpha3)));
+              Real sigma2 = sqrt(max(0. ,I1/3 - 2 * sqrt(alpha1) * cos(M_PI/3 + alpha3)));
+              Real sigma3 = sqrt(max(0. ,I1/3 - 2 * sqrt(alpha1) * cos(M_PI/3 - alpha3)));
+ 
+              Real verysmall = 1.e-24;
+              sigma2 = max(sigma3,sigma2);
+              sigma1 = max(sigma2,sigma1);
+              sigma1 = max(verysmall,sigma1);
+
+
+	      //       Compute the sigma operator
+              dst(i,j,k,n) = pow(Cs_cst * dx[idim],2) * ((sigma3 * (sigma1-sigma2) * (sigma2-sigma3)) / pow(sigma1,2));
+
+           }
+	});
+
+      } else {
+
+	amrex::Abort("\n DEBUG DONT KNOW THIS LES MODEL \n\n");
+
+      }
+                    
+    }
+    
+  }
+
+  */
+}
+

--- a/Source/NS_average.cpp
+++ b/Source/NS_average.cpp
@@ -21,70 +21,40 @@ using namespace amrex;
 //---------------------------------------------------------------------
 
 void
-NavierStokesBase::time_average(bool flag_init, amrex::Real&  time_avg, amrex::Real&  dt_avg, const Real& dt_level)
+NavierStokesBase::time_average(amrex::Real&  time_avg, amrex::Real&  dt_avg, const Real& dt_level)
 
 {
+  dt_avg = dt_avg + dt_level;
 
-   MultiFab& Savg   = get_new_data(Average_Type);
-      MultiFab& Savg_old   = get_old_data(Average_Type);
-
-
-      amrex::Print() << std::endl << " DEBUG S_OLD " << std::endl;
-      for (MFIter mfi(Savg_old,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-      {
-      amrex::Print() << Savg_old[mfi];
-      }
-amrex::Print() << std::endl << " DEBUG S_NEW " << std::endl;
-      for (MFIter mfi(Savg,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-      {
-      amrex::Print() << Savg[mfi];
-      }
-
-
-  if (flag_init)
+  if (parent->levelSteps(0)%avg_interval == 0)
   {
-
-    dt_avg   = 0;
-    time_avg = 0;
-
-  }
-  else
-  {
-
-    dt_avg = dt_avg + dt_level;
-
-    if (parent->levelSteps(0)%avg_interval == 0)
-    {
-      MultiFab& Sstate = get_new_data(State_Type);
-      MultiFab& Savg   = get_new_data(Average_Type); 
-      MultiFab& Savg_old   = get_old_data(Average_Type);
+    MultiFab& Sstate = get_new_data(State_Type);
+    MultiFab& Savg   = get_new_data(Average_Type); 
+    MultiFab& Savg_old   = get_old_data(Average_Type);
 
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-      for (MFIter mfi(Savg,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-      {
-         const Box& bx = mfi.tilebox();
-         auto const& S_state = Sstate.array(mfi,Xvel);
-         auto const& S_avg   = Savg.array(mfi);
-         auto const& S_avg_old   = Savg_old.array(mfi);
+    for (MFIter mfi(Savg,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+       const Box& bx = mfi.tilebox();
+       auto const& S_state = Sstate.array(mfi,Xvel);
+       auto const& S_avg   = Savg.array(mfi);
+       auto const& S_avg_old   = Savg_old.array(mfi);
 
-         amrex::ParallelFor(bx, BL_SPACEDIM, [S_state, S_avg, S_avg_old, dt_avg]
-         AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
-         {
-            S_avg(i,j,k,n) = S_avg_old(i,j,k,n) + dt_avg * S_state(i,j,k,n);
-            S_avg(i,j,k,n+BL_SPACEDIM) = S_avg_old(i,j,k,n+BL_SPACEDIM) + dt_avg * S_state(i,j,k,n) * S_state(i,j,k,n);
-            S_avg_old(i,j,k,n) = S_avg(i,j,k,n);
-            S_avg_old(i,j,k,n+BL_SPACEDIM) = S_avg(i,j,k,n+BL_SPACEDIM);
-         });
-      }
-
-      time_avg = time_avg + dt_avg;
-      dt_avg = 0;
-
+       amrex::ParallelFor(bx, BL_SPACEDIM, [S_state, S_avg, S_avg_old, dt_avg]
+       AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+       {
+          S_avg(i,j,k,n) = S_avg_old(i,j,k,n) + dt_avg * S_state(i,j,k,n);
+          S_avg(i,j,k,n+BL_SPACEDIM) = S_avg_old(i,j,k,n+BL_SPACEDIM) + dt_avg * S_state(i,j,k,n) * S_state(i,j,k,n);
+          S_avg_old(i,j,k,n) = S_avg(i,j,k,n);
+          S_avg_old(i,j,k,n+BL_SPACEDIM) = S_avg(i,j,k,n+BL_SPACEDIM);
+       });
     }
 
-  }
+    time_avg = time_avg + dt_avg;
+    dt_avg = 0;
 
+  }
 }
 

--- a/Source/NS_average.cpp
+++ b/Source/NS_average.cpp
@@ -18,8 +18,6 @@ using namespace amrex;
 //  The average is dumped in each plotfile.
 //
 //  Do not forget to add "velocity_average" in amr.derive_plot_vars.
-//  The averaging process starts from the initial/restart solution,
-//  this means that the averaging from previous runs are forgotten.
 //---------------------------------------------------------------------
 
 void
@@ -32,7 +30,7 @@ NavierStokesBase::time_average(bool flag_init, amrex::Real&  time_avg, amrex::Re
 
     dt_avg   = 0;
     time_avg = 0;
-
+/*
     MultiFab& Sstate = get_new_data(State_Type);
     MultiFab& Savg   = get_new_data(Average_Type);
     MultiFab& Savg_old   = get_old_data(Average_Type);
@@ -56,6 +54,22 @@ NavierStokesBase::time_average(bool flag_init, amrex::Real&  time_avg, amrex::Re
           S_avg_old(i,j,k,n+BL_SPACEDIM) = 0.; //S_avg(i,j,k,n+BL_SPACEDIM);
        });
     }
+*/
+
+      MultiFab& Savg   = get_new_data(Average_Type);
+      MultiFab& Savg_old   = get_old_data(Average_Type);
+
+
+      amrex::Print() << std::endl << " DEBUG S_OLD " << std::endl;
+      for (MFIter mfi(Savg_old,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+      {
+      amrex::Print() << Savg_old[mfi];
+      }
+amrex::Print() << std::endl << " DEBUG S_NEW " << std::endl;
+      for (MFIter mfi(Savg,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+      {
+      amrex::Print() << Savg[mfi];
+      }
 
   }
   else
@@ -69,6 +83,34 @@ NavierStokesBase::time_average(bool flag_init, amrex::Real&  time_avg, amrex::Re
       MultiFab& Savg   = get_new_data(Average_Type); 
       MultiFab& Savg_old   = get_old_data(Average_Type);
 
+/*
+MultiFab& Stest   = get_old_data(Average_Type);
+Stest.setVal(0.);
+FillPatchIterator U_fpi(*this,Stest,0,state[Average_Type].curTime(),Average_Type,Xvel,BL_SPACEDIM*2);
+    MultiFab& Umf=U_fpi.get_mf();
+if (level > 0){
+
+amrex::Print() << std::endl << " DEBUG TEST NEW " << std::endl;
+      for (MFIter mfi(Umf,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+      {
+      amrex::Print() << Umf[mfi];
+      }
+}
+*/
+
+
+      amrex::Print() << std::endl << " DEBUG S_OLD " << std::endl;
+      for (MFIter mfi(Savg_old,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+      {
+      amrex::Print() << Savg_old[mfi];
+      }
+amrex::Print() << std::endl << " DEBUG S_NEW " << std::endl;
+      for (MFIter mfi(Savg,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+      {
+      amrex::Print() << Savg[mfi];
+      }
+
+
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
@@ -78,6 +120,10 @@ NavierStokesBase::time_average(bool flag_init, amrex::Real&  time_avg, amrex::Re
          auto const& S_state = Sstate.array(mfi,Xvel);
          auto const& S_avg   = Savg.array(mfi);
          auto const& S_avg_old   = Savg_old.array(mfi);
+
+  //    amrex::Print() << std::endl << " DEBUG S_OLD " << std::endl;
+  //    amrex::Print() << Savg_old[mfi];
+
 
          amrex::ParallelFor(bx, BL_SPACEDIM, [S_state, S_avg, S_avg_old, dt_avg]
          AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept

--- a/Source/NS_derive.H
+++ b/Source/NS_derive.H
@@ -1,0 +1,14 @@
+
+#ifndef NS_DERIVE_CPP_H
+#define NS_DERIVE_CPP_H
+
+#include <AMReX_FArrayBox.H>
+#include <AMReX_Geometry.H>
+
+
+    void der_vel_avg (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int ncomp,
+                      const amrex::FArrayBox& datafab, const amrex::Geometry& geomdata,
+                      amrex::Real time, const int* bcrec, int level);
+
+
+#endif

--- a/Source/NS_derive.cpp
+++ b/Source/NS_derive.cpp
@@ -15,7 +15,7 @@ void der_vel_avg (const Box& bx, FArrayBox& derfab, int dcomp, int ncomp,
     AMREX_ASSERT(datfab.box().contains(bx));
     AMREX_ASSERT(derfab.nComp() >= dcomp + ncomp);
     AMREX_ASSERT(datfab.nComp() >= BL_SPACEDIM*2);
-    AMREX_ASSERT(ncomp == BL_SPACEDIM);
+    AMREX_ASSERT(ncomp == BL_SPACEDIM*2);
     auto const in_dat = datfab.array();
     auto          der = derfab.array(dcomp);
 

--- a/Source/NS_derive.cpp
+++ b/Source/NS_derive.cpp
@@ -20,7 +20,7 @@ void der_vel_avg (const Box& bx, FArrayBox& derfab, int dcomp, int ncomp,
     auto          der = derfab.array(dcomp);
 
 
-    amrex::Real inv_time = NavierStokesBase::time_avg[level];
+    amrex::Real inv_time = 1.0 / NavierStokesBase::time_avg[level];
 
     amrex::ParallelFor(bx, BL_SPACEDIM, [inv_time,der,in_dat]
     AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept

--- a/Source/NS_derive.cpp
+++ b/Source/NS_derive.cpp
@@ -1,0 +1,35 @@
+#include <NavierStokesBase.H>
+#include "NS_derive.H"
+
+
+using namespace amrex;
+
+
+
+void der_vel_avg (const Box& bx, FArrayBox& derfab, int dcomp, int ncomp,
+                  const FArrayBox& datfab, const Geometry& /*geomdata*/,
+                  Real time, const int* /*bcrec*/, int level)
+
+{
+    AMREX_ASSERT(derfab.box().contains(bx));
+    AMREX_ASSERT(datfab.box().contains(bx));
+    AMREX_ASSERT(derfab.nComp() >= dcomp + ncomp);
+    AMREX_ASSERT(datfab.nComp() >= BL_SPACEDIM);
+    AMREX_ASSERT(ncomp == BL_SPACEDIM);
+    auto const in_dat = datfab.array();
+    auto          der = derfab.array(dcomp);
+
+
+    amrex::ParallelFor(bx, BL_SPACEDIM,
+    [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+    {
+        der(i,j,k,n) = in_dat(i,j,k,n);
+    });
+    amrex::Print() << " " << std::endl;
+    amrex::Print() << "DEBUG in der_vel_avg level = " << level << std::endl;
+    amrex::Print() << "DEBUG in der_vel_avg time_avg = " << NavierStokesBase::time_avg[level] << std::endl;
+
+    amrex::Print() << " " << std::endl;
+
+}
+

--- a/Source/NS_derive.cpp
+++ b/Source/NS_derive.cpp
@@ -18,9 +18,13 @@ void der_vel_avg (const Box& bx, FArrayBox& derfab, int dcomp, int ncomp,
     AMREX_ASSERT(ncomp == BL_SPACEDIM*2);
     auto const in_dat = datfab.array();
     auto          der = derfab.array(dcomp);
+    amrex::Real inv_time;
 
-
-    amrex::Real inv_time = 1.0 / NavierStokesBase::time_avg[level];
+    if (NavierStokesBase::time_avg[level] == 0){
+      inv_time = 1.0;
+    }else{
+      inv_time = 1.0 / NavierStokesBase::time_avg[level];
+    }
 
     amrex::ParallelFor(bx, BL_SPACEDIM, [inv_time,der,in_dat]
     AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept

--- a/Source/NS_setup.cpp
+++ b/Source/NS_setup.cpp
@@ -294,30 +294,8 @@ NavierStokes::variableSetUp ()
     set_pressure_bc(bc,phys_bc);
     desc_lst.setComponent(Press_Type,Pressure,"pressure",bc,BndryFunc(FORT_PRESFILL));
 
-    if (do_temp)
-    {
-	// stick Divu_Type on the end of the descriptor list
-	Divu_Type = desc_lst.size();
-	int nGrowDivu = 1;
-	desc_lst.addDescriptor(Divu_Type,IndexType::TheCellType(),
-                               StateDescriptor::Point,nGrowDivu,1,
-			       &cc_interp);
-	set_divu_bc(bc,phys_bc);
-	desc_lst.setComponent(Divu_Type,Divu,"divu",bc,BndryFunc(FORT_DIVUFILL));
-	
-	// stick Dsdt_Type on the end of the descriptor list
-	Dsdt_Type = desc_lst.size();
-	int nGrowDsdt = 0;
-	desc_lst.addDescriptor(Dsdt_Type,IndexType::TheCellType(),
-                               StateDescriptor::Point,nGrowDsdt,1,
-			       &cc_interp);
-	set_dsdt_bc(bc,phys_bc);
-	desc_lst.setComponent(Dsdt_Type,Dsdt,"dsdt",bc,BndryFunc(FORT_DSDTFILL));
-    }
-
     if (NavierStokesBase::avg_interval > 0)
     {
-      Average_Type = desc_lst.size();
       bool state_data_extrap = false;
       bool store_in_checkpoint = true;
       desc_lst.addDescriptor(Average_Type,IndexType::TheCellType(),
@@ -349,6 +327,27 @@ NavierStokes::variableSetUp ()
                      var_names_ave,der_vel_avg,the_same_box);
       derive_lst.addComponent("velocity_average",desc_lst,Average_Type,Xvel,BL_SPACEDIM*2);
 
+    }
+
+    if (do_temp)
+    {
+	// stick Divu_Type on the end of the descriptor list
+	Divu_Type = desc_lst.size();
+	int nGrowDivu = 1;
+	desc_lst.addDescriptor(Divu_Type,IndexType::TheCellType(),
+                               StateDescriptor::Point,nGrowDivu,1,
+			       &cc_interp);
+	set_divu_bc(bc,phys_bc);
+	desc_lst.setComponent(Divu_Type,Divu,"divu",bc,BndryFunc(FORT_DIVUFILL));
+	
+	// stick Dsdt_Type on the end of the descriptor list
+	Dsdt_Type = desc_lst.size();
+	int nGrowDsdt = 0;
+	desc_lst.addDescriptor(Dsdt_Type,IndexType::TheCellType(),
+                               StateDescriptor::Point,nGrowDsdt,1,
+			       &cc_interp);
+	set_dsdt_bc(bc,phys_bc);
+	desc_lst.setComponent(Dsdt_Type,Dsdt,"dsdt",bc,BndryFunc(FORT_DSDTFILL));
     }
 
     //

--- a/Source/NS_setup.cpp
+++ b/Source/NS_setup.cpp
@@ -294,8 +294,30 @@ NavierStokes::variableSetUp ()
     set_pressure_bc(bc,phys_bc);
     desc_lst.setComponent(Press_Type,Pressure,"pressure",bc,BndryFunc(FORT_PRESFILL));
 
-    if (NavierStokesBase::avg_interval > 0)
+    if (do_temp)
     {
+	// stick Divu_Type on the end of the descriptor list
+	Divu_Type = desc_lst.size();
+	int nGrowDivu = 1;
+	desc_lst.addDescriptor(Divu_Type,IndexType::TheCellType(),
+                               StateDescriptor::Point,nGrowDivu,1,
+			       &cc_interp);
+	set_divu_bc(bc,phys_bc);
+	desc_lst.setComponent(Divu_Type,Divu,"divu",bc,BndryFunc(FORT_DIVUFILL));
+	
+	// stick Dsdt_Type on the end of the descriptor list
+	Dsdt_Type = desc_lst.size();
+	int nGrowDsdt = 0;
+	desc_lst.addDescriptor(Dsdt_Type,IndexType::TheCellType(),
+                               StateDescriptor::Point,nGrowDsdt,1,
+			       &cc_interp);
+	set_dsdt_bc(bc,phys_bc);
+	desc_lst.setComponent(Dsdt_Type,Dsdt,"dsdt",bc,BndryFunc(FORT_DSDTFILL));
+    }
+
+    if (NavierStokesBase::avg_interval > 0)
+    { 
+      Average_Type = desc_lst.size();
       bool state_data_extrap = false;
       bool store_in_checkpoint = true;
       desc_lst.addDescriptor(Average_Type,IndexType::TheCellType(),
@@ -327,27 +349,6 @@ NavierStokes::variableSetUp ()
                      var_names_ave,der_vel_avg,the_same_box);
       derive_lst.addComponent("velocity_average",desc_lst,Average_Type,Xvel,BL_SPACEDIM*2);
 
-    }
-
-    if (do_temp)
-    {
-	// stick Divu_Type on the end of the descriptor list
-	Divu_Type = desc_lst.size();
-	int nGrowDivu = 1;
-	desc_lst.addDescriptor(Divu_Type,IndexType::TheCellType(),
-                               StateDescriptor::Point,nGrowDivu,1,
-			       &cc_interp);
-	set_divu_bc(bc,phys_bc);
-	desc_lst.setComponent(Divu_Type,Divu,"divu",bc,BndryFunc(FORT_DIVUFILL));
-	
-	// stick Dsdt_Type on the end of the descriptor list
-	Dsdt_Type = desc_lst.size();
-	int nGrowDsdt = 0;
-	desc_lst.addDescriptor(Dsdt_Type,IndexType::TheCellType(),
-                               StateDescriptor::Point,nGrowDsdt,1,
-			       &cc_interp);
-	set_dsdt_bc(bc,phys_bc);
-	desc_lst.setComponent(Dsdt_Type,Dsdt,"dsdt",bc,BndryFunc(FORT_DSDTFILL));
     }
 
     //

--- a/Source/NS_setup.cpp
+++ b/Source/NS_setup.cpp
@@ -319,7 +319,7 @@ NavierStokes::variableSetUp ()
     {
       Average_Type = desc_lst.size();
       bool state_data_extrap = false;
-      bool store_in_checkpoint = false;
+      bool store_in_checkpoint = true;
       desc_lst.addDescriptor(Average_Type,IndexType::TheCellType(),
                              StateDescriptor::Point,0,BL_SPACEDIM*2,
                              &cc_interp,state_data_extrap,store_in_checkpoint);

--- a/Source/NS_setup.cpp
+++ b/Source/NS_setup.cpp
@@ -315,46 +315,44 @@ NavierStokes::variableSetUp ()
 	desc_lst.setComponent(Dsdt_Type,Dsdt,"dsdt",bc,BndryFunc(FORT_DSDTFILL));
     }
 
+    if (NavierStokesBase::avg_interval > 0)
+    {
+      Average_Type = desc_lst.size();
+      bool state_data_extrap = false;
+      bool store_in_checkpoint = false;
+      desc_lst.addDescriptor(Average_Type,IndexType::TheCellType(),
+                             StateDescriptor::Point,0,BL_SPACEDIM*2,
+                             &cc_interp,state_data_extrap,store_in_checkpoint);
 
-// TO DO MAKE A CHECK STATEMENT HERE: WE DONT WANT TO ALWAYS AVERAGE
-   {
-    Average_Type = desc_lst.size();
-    bool state_data_extrap = false;
-    bool store_in_checkpoint = true;
-    desc_lst.addDescriptor(Average_Type,IndexType::TheCellType(),
-                           StateDescriptor::Point,0,BL_SPACEDIM,
-                           &cc_interp,state_data_extrap,store_in_checkpoint);
+      set_average_bc(bc,phys_bc);
+      desc_lst.setComponent(Average_Type,Xvel,"xvel_avg_dummy",bc,BndryFunc(FORT_DSDTFILL));
+      desc_lst.setComponent(Average_Type,Xvel+BL_SPACEDIM,"xvel_rms_dummy",bc,BndryFunc(FORT_DSDTFILL));
+      desc_lst.setComponent(Average_Type,Yvel,"yvel_avg_dummy",bc,BndryFunc(FORT_DSDTFILL));
+      desc_lst.setComponent(Average_Type,Yvel+BL_SPACEDIM,"yvel_rms_dummy",bc,BndryFunc(FORT_DSDTFILL));
+#if (BL_SPACEDIM==3)
+      desc_lst.setComponent(Average_Type,Zvel,"zvel_avg_dummy",bc,BndryFunc(FORT_DSDTFILL));
+      desc_lst.setComponent(Average_Type,Zvel+BL_SPACEDIM,"zvel_rms_dummy",bc,BndryFunc(FORT_DSDTFILL));
+#endif
 
-    set_average_bc(bc,phys_bc);
-    desc_lst.setComponent(Average_Type,Xvel,"x_vel_average",bc,BndryFunc(FORT_DSDTFILL));
+      Vector<std::string> var_names_ave(BL_SPACEDIM*2);
+      var_names_ave[Xvel] = "x_vel_average";
+      var_names_ave[Yvel] = "y_vel_average";
+#if (BL_SPACEDIM==3)
+      var_names_ave[Zvel] = "z_vel_average";
+#endif
+      var_names_ave[Xvel+BL_SPACEDIM] = "x_vel_rms";
+      var_names_ave[Yvel+BL_SPACEDIM] = "y_vel_rms";
+#if (BL_SPACEDIM==3)
+      var_names_ave[Zvel+BL_SPACEDIM] = "z_vel_rms";
+#endif
+      derive_lst.add("velocity_average",IndexType::TheCellType(),BL_SPACEDIM*2,
+                     var_names_ave,der_vel_avg,the_same_box);
+      derive_lst.addComponent("velocity_average",desc_lst,Average_Type,Xvel,BL_SPACEDIM*2);
 
-    desc_lst.setComponent(Average_Type,Yvel,"y_vel_average",bc,BndryFunc(FORT_DSDTFILL));
-}
-
-
-
-
+    }
 
     //
     // **************  DEFINE DERIVED QUANTITIES ********************
-
-
-
-  Vector<std::string> var_names_ave(BL_SPACEDIM);
-  var_names_ave[0] = "x_vel_ave";
-  var_names_ave[1] = "y_vel_ave";
-// TO DO 3D
-  derive_lst.add("velocity_average",IndexType::TheCellType(),BL_SPACEDIM,
-                 var_names_ave,der_vel_avg,the_same_box);
-  derive_lst.addComponent("velocity_average",desc_lst,State_Type,Xvel,BL_SPACEDIM);
-
-
-
-
-
-
-
-
     //
     // mod grad rho
     //

--- a/Source/NS_setup.cpp
+++ b/Source/NS_setup.cpp
@@ -293,7 +293,7 @@ NavierStokes::variableSetUp ()
 
     set_pressure_bc(bc,phys_bc);
     desc_lst.setComponent(Press_Type,Pressure,"pressure",bc,BndryFunc(FORT_PRESFILL));
- 
+
     if (do_temp)
     {
 	// stick Divu_Type on the end of the descriptor list

--- a/Source/NavierStokes.cpp
+++ b/Source/NavierStokes.cpp
@@ -1569,11 +1569,15 @@ NavierStokes::post_init (Real stop_time)
 #endif
 
 // TO DO: PUT THAT IN RESTART
-    NavierStokesBase::time_avg.resize(finest_level); 
-    NavierStokesBase::dt_avg.resize(finest_level);
-    NavierStokesBase::dt_avg={0};
-    NavierStokesBase::time_avg={0};
+    NavierStokesBase::time_avg.resize(finest_level+1); 
+    NavierStokesBase::dt_avg.resize(finest_level+1);
 
+    {
+      bool flag_init = true;
+      const amrex::Real dt_level = parent->dtLevel(level);
+      time_average(flag_init, NavierStokesBase::time_avg[level], NavierStokesBase::dt_avg[level], dt_level);
+
+    }
 }
 
 //

--- a/Source/NavierStokes.cpp
+++ b/Source/NavierStokes.cpp
@@ -93,6 +93,10 @@ NavierStokes::initData ()
     const Real* dx       = geom.CellSize();
     MultiFab&   S_new    = get_new_data(State_Type);
     MultiFab&   P_new    = get_new_data(Press_Type);
+    if (avg_interval > 0){
+      MultiFab&   Save_new    = get_new_data(Average_Type);
+      Save_new.setVal(0.);
+    }
     const Real  cur_time = state[State_Type].curTime();
 #ifdef _OPENMP
 #pragma omp parallel  if (Gpu::notInLaunchRegion())
@@ -1525,6 +1529,7 @@ NavierStokes::derive (const std::string& name,
 void
 NavierStokes::post_init (Real stop_time)
 {
+
     if (level > 0)
         //
         // Nothing to sync up at level > 0.
@@ -1568,16 +1573,34 @@ NavierStokes::post_init (Real stop_time)
 #endif
 #endif
 
-    if (NavierStokesBase::avg_interval > 0)
+       if (NavierStokesBase::avg_interval > 0)
     {
-      NavierStokesBase::time_avg.resize(finest_level+1); 
+      const int   finest_level = parent->finestLevel();
+      NavierStokesBase::time_avg.resize(finest_level+1);
       NavierStokesBase::dt_avg.resize(finest_level+1);
-
       bool flag_init = true;
       const amrex::Real dt_level = parent->dtLevel(level);
       time_average(flag_init, NavierStokesBase::time_avg[level], NavierStokesBase::dt_avg[level], dt_level);
-
     }
+
+/*
+  MultiFab& Savg   = get_new_data(Average_Type);
+      MultiFab& Savg_old   = get_old_data(Average_Type);
+
+      amrex::Print() << std::endl << " DEBUG S_OLD " << std::endl;
+      for (MFIter mfi(Savg_old,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+      {
+      amrex::Print() << Savg_old[mfi];
+      }
+amrex::Print() << std::endl << " DEBUG S_NEW " << std::endl;
+      for (MFIter mfi(Savg,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+      {
+      amrex::Print() << Savg[mfi];
+      }
+*/
+
+
+
 }
 
 //

--- a/Source/NavierStokes.cpp
+++ b/Source/NavierStokes.cpp
@@ -1573,7 +1573,7 @@ NavierStokes::post_init (Real stop_time)
 #endif
 #endif
 
-       if (NavierStokesBase::avg_interval > 0)
+    if (NavierStokesBase::avg_interval > 0)
     {
       const int   finest_level = parent->finestLevel();
       NavierStokesBase::time_avg.resize(finest_level+1);
@@ -1582,24 +1582,6 @@ NavierStokes::post_init (Real stop_time)
       const amrex::Real dt_level = parent->dtLevel(level);
       time_average(flag_init, NavierStokesBase::time_avg[level], NavierStokesBase::dt_avg[level], dt_level);
     }
-
-/*
-  MultiFab& Savg   = get_new_data(Average_Type);
-      MultiFab& Savg_old   = get_old_data(Average_Type);
-
-      amrex::Print() << std::endl << " DEBUG S_OLD " << std::endl;
-      for (MFIter mfi(Savg_old,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-      {
-      amrex::Print() << Savg_old[mfi];
-      }
-amrex::Print() << std::endl << " DEBUG S_NEW " << std::endl;
-      for (MFIter mfi(Savg,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-      {
-      amrex::Print() << Savg[mfi];
-      }
-*/
-
-
 
 }
 

--- a/Source/NavierStokes.cpp
+++ b/Source/NavierStokes.cpp
@@ -1568,11 +1568,11 @@ NavierStokes::post_init (Real stop_time)
 #endif
 #endif
 
-// TO DO: PUT THAT IN RESTART
-    NavierStokesBase::time_avg.resize(finest_level+1); 
-    NavierStokesBase::dt_avg.resize(finest_level+1);
-
+    if (NavierStokesBase::avg_interval > 0)
     {
+      NavierStokesBase::time_avg.resize(finest_level+1); 
+      NavierStokesBase::dt_avg.resize(finest_level+1);
+
       bool flag_init = true;
       const amrex::Real dt_level = parent->dtLevel(level);
       time_average(flag_init, NavierStokesBase::time_avg[level], NavierStokesBase::dt_avg[level], dt_level);

--- a/Source/NavierStokes.cpp
+++ b/Source/NavierStokes.cpp
@@ -1578,9 +1578,10 @@ NavierStokes::post_init (Real stop_time)
       const int   finest_level = parent->finestLevel();
       NavierStokesBase::time_avg.resize(finest_level+1);
       NavierStokesBase::dt_avg.resize(finest_level+1);
-      bool flag_init = true;
+      NavierStokesBase::time_avg[level] = 0.;
+      NavierStokesBase::dt_avg[level] = 0.;
       const amrex::Real dt_level = parent->dtLevel(level);
-      time_average(flag_init, NavierStokesBase::time_avg[level], NavierStokesBase::dt_avg[level], dt_level);
+      time_average(NavierStokesBase::time_avg[level], NavierStokesBase::dt_avg[level], dt_level);
     }
 
 }

--- a/Source/NavierStokes.cpp
+++ b/Source/NavierStokes.cpp
@@ -1567,6 +1567,13 @@ NavierStokes::post_init (Real stop_time)
         sum_jet_quantities();
 #endif
 #endif
+
+// TO DO: PUT THAT IN RESTART
+    NavierStokesBase::time_avg.resize(finest_level); 
+    NavierStokesBase::dt_avg.resize(finest_level);
+    NavierStokesBase::dt_avg={0};
+    NavierStokesBase::time_avg={0};
+
 }
 
 //

--- a/Source/NavierStokesBase.H
+++ b/Source/NavierStokesBase.H
@@ -207,7 +207,7 @@ public:
 
     void calc_mut_LES(amrex::MultiFab*  diffusivity[BL_SPACEDIM], amrex::Real time);
 
-    void time_average(bool flag_init, amrex::Real& time_avg, amrex::Real& dt_avg, const amrex::Real& dt_level);
+    void time_average(amrex::Real& time_avg, amrex::Real& dt_avg, const amrex::Real& dt_level);
 
     ////////////////////////////////////////////////////////////////////////////
     //    NavierStokesBase public static functions                            //

--- a/Source/NavierStokesBase.H
+++ b/Source/NavierStokesBase.H
@@ -33,7 +33,7 @@
 // Determine what you want in the state -- Divu, Dsdt -- in
 // NavierStokes::variableSetUp in NS_setup.cpp.
 //
-enum StateType {State_Type=0, Press_Type, Average_Type};
+enum StateType {State_Type=0, Press_Type};
 
 //
 // Note: enumerated value NUM_STATE_TYPE no longer defined
@@ -770,6 +770,7 @@ public:
     static int  additional_state_types_initialized;
     static int  Divu_Type;
     static int  Dsdt_Type;
+    static int  Average_Type;
     static int  num_state_type;
     static int  have_divu;
     static int  have_dsdt;

--- a/Source/NavierStokesBase.H
+++ b/Source/NavierStokesBase.H
@@ -203,7 +203,7 @@ public:
 
     void calc_mut_LES(amrex::MultiFab*  diffusivity[BL_SPACEDIM], amrex::Real time);
 
-    void time_average(int flag_init, amrex::Real& dt_avg, const amrex::Real& dt_level);
+    void time_average(bool flag_init, amrex::Real& time_avg, amrex::Real& dt_avg, const amrex::Real& dt_level);
 
     ////////////////////////////////////////////////////////////////////////////
     //    NavierStokesBase public static functions                            //

--- a/Source/NavierStokesBase.H
+++ b/Source/NavierStokesBase.H
@@ -16,7 +16,6 @@
 #include <Projection.H>
 #include <SyncRegister.H>
 #include <AMReX_Utility.H>
-#include <AMReX.H>
 
 #ifdef AMREX_PARTICLES
 #include <AMReX_AmrParticles.H>

--- a/Source/NavierStokesBase.H
+++ b/Source/NavierStokesBase.H
@@ -757,9 +757,9 @@ public:
     //
     // Parameters for averaging
     //
-//    static amrex::Real time_avg;  // Physical time between 2 averages (same for all levels)
     static amrex::Vector<amrex::Real> time_avg;
     static amrex::Vector<amrex::Real> dt_avg;
+    static int avg_interval;
     //
     // Members for non-zero divu.
     //

--- a/Source/NavierStokesBase.H
+++ b/Source/NavierStokesBase.H
@@ -16,6 +16,7 @@
 #include <Projection.H>
 #include <SyncRegister.H>
 #include <AMReX_Utility.H>
+#include <AMReX.H>
 
 #ifdef AMREX_PARTICLES
 #include <AMReX_AmrParticles.H>
@@ -201,6 +202,8 @@ public:
 		      int scomp, int ncomp);
 
     void calc_mut_LES(amrex::MultiFab*  diffusivity[BL_SPACEDIM], amrex::Real time);
+
+    void time_average(int flag_init, amrex::Real& dt_avg, const amrex::Real& dt_level);
 
     ////////////////////////////////////////////////////////////////////////////
     //    NavierStokesBase public static functions                            //
@@ -752,11 +755,18 @@ public:
     static amrex::Real smago_Cs_cst;       // A parameter for the Smagorinsky model, usually set to 0.18
     static amrex::Real sigma_Cs_cst;       // A parameter for the Sigma model, usually set to 1.5
     //
+    // Parameters for averaging
+    //
+//    static amrex::Real time_avg;  // Physical time between 2 averages (same for all levels)
+    static amrex::Vector<amrex::Real> time_avg;
+    static amrex::Vector<amrex::Real> dt_avg;
+    //
     // Members for non-zero divu.
     //
     static int  additional_state_types_initialized;
     static int  Divu_Type;
     static int  Dsdt_Type;
+    static int  Average_Type;
     static int  num_state_type;
     static int  have_divu;
     static int  have_dsdt;

--- a/Source/NavierStokesBase.H
+++ b/Source/NavierStokesBase.H
@@ -33,7 +33,7 @@
 // Determine what you want in the state -- Divu, Dsdt -- in
 // NavierStokes::variableSetUp in NS_setup.cpp.
 //
-enum StateType {State_Type=0, Press_Type};
+enum StateType {State_Type=0, Press_Type, Average_Type};
 
 //
 // Note: enumerated value NUM_STATE_TYPE no longer defined
@@ -137,6 +137,11 @@ public:
     virtual void restart (amrex::Amr&          papa,
                           std::istream& is,
                           bool          bReadSpecial = false) override;
+    // Old checkpoint file may have different number of state types than the
+    // new source code.
+    //
+    virtual void set_state_in_checkpoint (amrex::Vector<int>& state_in_checkpoint) override;
+    
     //
     // Set time levels of state data.
     //
@@ -765,7 +770,6 @@ public:
     static int  additional_state_types_initialized;
     static int  Divu_Type;
     static int  Dsdt_Type;
-    static int  Average_Type;
     static int  num_state_type;
     static int  have_divu;
     static int  have_dsdt;
@@ -809,6 +813,8 @@ public:
 #else
     static const int  godunov_hyp_grow = 3;
 #endif
+
+    static bool average_in_checkpoint;
 
 };
 

--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -978,29 +978,30 @@ NavierStokesBase::checkPoint (const std::string& dir,
 {
   AmrLevel::checkPoint(dir, os, how, dump_old);
 
-  VisMF::IO_Buffer io_buffer(VisMF::IO_Buffer_Size);
+  if (avg_interval > 0){
+    VisMF::IO_Buffer io_buffer(VisMF::IO_Buffer_Size);
 
-  if (ParallelDescriptor::IOProcessor()) {
+    if (ParallelDescriptor::IOProcessor()) {
 
-    std::ofstream TImeAverageFile;
-    TImeAverageFile.rdbuf()->pubsetbuf(io_buffer.dataPtr(), io_buffer.size());
-    std::string TAFileName(dir + "/TimeAverage");
-    TImeAverageFile.open(TAFileName.c_str(), std::ofstream::out   |
-                  std::ofstream::trunc |
-                  std::ofstream::binary);
+      std::ofstream TImeAverageFile;
+      TImeAverageFile.rdbuf()->pubsetbuf(io_buffer.dataPtr(), io_buffer.size());
+      std::string TAFileName(dir + "/TimeAverage");
+      TImeAverageFile.open(TAFileName.c_str(), std::ofstream::out   |
+                    std::ofstream::trunc |
+                    std::ofstream::binary);
 
-    if( !TImeAverageFile.good()) {
-         amrex::FileOpenFailed(TAFileName);
-    }
+      if( !TImeAverageFile.good()) {
+           amrex::FileOpenFailed(TAFileName);
+      }
 
-    TImeAverageFile.precision(17);
+      TImeAverageFile.precision(17);
 
-    // write out title line
-    TImeAverageFile << "Writing time_average to checkpoint\n";
+      // write out title line
+      TImeAverageFile << "Writing time_average to checkpoint\n";
     
-              TImeAverageFile << NavierStokesBase::time_avg[level] << "\n";
+      TImeAverageFile << NavierStokesBase::time_avg[level] << "\n";
     }
-
+  }
 
 #ifdef AMREX_PARTICLES
     if (level == 0)

--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -2670,11 +2670,11 @@ NavierStokesBase::post_timestep (int crse_iteration)
     }
 
     {
-      int flag_init = 0;
+      bool flag_init = false;
       const amrex::Real dt_level = parent->dtLevel(level);
 amrex::Print() << " " << std::endl;
 amrex::Print() << " DEBUG CALLING TIME_AVERAGE ON LEVEL " << level << std::endl;
-      time_average(flag_init, NavierStokesBase::dt_avg[level], dt_level);
+      time_average(flag_init, time_avg[level], dt_avg[level], dt_level);
 amrex::Print() << " DEBUG AFTER TIME_AVERAGE  " << NavierStokesBase::dt_avg[level] << std::endl;
 
     }

--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -118,9 +118,14 @@ std::string NavierStokesBase::LES_model                 = "Smagorinsky";
 Real        NavierStokesBase::smago_Cs_cst              = 0.18;
 Real        NavierStokesBase::sigma_Cs_cst              = 1.5;
 
+//amrex::Real NavierStokesBase::time_avg;
+amrex::Vector<amrex::Real> NavierStokesBase::time_avg;
+amrex::Vector<amrex::Real> NavierStokesBase::dt_avg;
+
 int  NavierStokesBase::additional_state_types_initialized = 0;
 int  NavierStokesBase::Divu_Type                          = -1;
 int  NavierStokesBase::Dsdt_Type                          = -1;
+int  NavierStokesBase::Average_Type                          = -1;
 int  NavierStokesBase::num_state_type                     = 2;
 int  NavierStokesBase::have_divu                          = 0;
 int  NavierStokesBase::have_dsdt                          = 0;
@@ -2624,6 +2629,7 @@ NavierStokesBase::post_timestep (int crse_iteration)
 #endif
 #endif
 
+
     if (level > 0) incrPAvg();
 
     old_intersect_new          = grids;
@@ -2662,6 +2668,17 @@ NavierStokesBase::post_timestep (int crse_iteration)
             mf[0].writeOn(ofs);
         }
     }
+
+    {
+      int flag_init = 0;
+      const amrex::Real dt_level = parent->dtLevel(level);
+amrex::Print() << " " << std::endl;
+amrex::Print() << " DEBUG CALLING TIME_AVERAGE ON LEVEL " << level << std::endl;
+      time_average(flag_init, NavierStokesBase::dt_avg[level], dt_level);
+amrex::Print() << " DEBUG AFTER TIME_AVERAGE  " << NavierStokesBase::dt_avg[level] << std::endl;
+
+    }
+
 }
 
 //

--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -797,9 +797,13 @@ NavierStokesBase::advance_setup (Real time,
     //
     // Set up state multifabs for the advance.
     //
+amrex::Print() << "/n RAAAAAHHHHH num_state_type " << num_state_type << "\n";
     for (int k = 0; k < num_state_type; k++)
     {
 	bool has_old_data = state[k].hasOldData();
+amrex::Print() << "/n RAAAAAHHHHH k " << k << "\n";
+amrex::Print() << "/n RAAAAAHHHHH has_old_data " << has_old_data << "\n";
+
         state[k].allocOldData();
 	if (! has_old_data) state[k].oldData().setVal(0.0);
         state[k].swapTimeLevels(dt);
@@ -1829,6 +1833,11 @@ NavierStokesBase::init (AmrLevel &old)
        }
     }
 
+    if (avg_interval > 0){
+      MultiFab& Save_new = get_new_data(Average_Type);
+      FillPatch(old,Save_new,0,cur_time,Average_Type,0,BL_SPACEDIM*2);
+    }
+
     //
     // Get best divu and dSdt data.
     //
@@ -2552,6 +2561,8 @@ NavierStokesBase::post_regrid (int lbase,
         NSPC->Redistribute(lbase);
     }
 #endif
+
+
 }
 
 //
@@ -2682,12 +2693,49 @@ NavierStokesBase::post_timestep (int crse_iteration)
         }
     }
 
+/*
+     MultiFab& Savg   = get_new_data(Average_Type);
+      MultiFab& Savg_old   = get_old_data(Average_Type);
+
+      amrex::Print() << std::endl << " DEBUG S_OLD " << std::endl;
+      for (MFIter mfi(Savg_old,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+      {
+      amrex::Print() << Savg_old[mfi];
+      }
+amrex::Print() << std::endl << " DEBUG S_NEW " << std::endl;
+      for (MFIter mfi(Savg,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+      {
+      amrex::Print() << Savg[mfi];
+      }
+*/
+
+
+
+
     if (avg_interval > 0)
     {
       bool flag_init = false;
       const amrex::Real dt_level = parent->dtLevel(level);
       time_average(flag_init, time_avg[level], dt_avg[level], dt_level);
     }
+
+
+/*
+  MultiFab& Savg   = get_new_data(Average_Type);
+      MultiFab& Savg_old   = get_old_data(Average_Type);
+
+      amrex::Print() << std::endl << " DEBUG S_OLD " << std::endl;
+      for (MFIter mfi(Savg_old,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+      {
+      amrex::Print() << Savg_old[mfi];
+      }
+amrex::Print() << std::endl << " DEBUG S_NEW " << std::endl;
+      for (MFIter mfi(Savg,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+      {
+      amrex::Print() << Savg[mfi];
+      }
+*/
+
 
 }
 

--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -125,6 +125,7 @@ int  NavierStokesBase::avg_interval                    = 0;
 int  NavierStokesBase::additional_state_types_initialized = 0;
 int  NavierStokesBase::Divu_Type                          = -1;
 int  NavierStokesBase::Dsdt_Type                          = -1;
+int  NavierStokesBase::Average_Type                       = -1;
 int  NavierStokesBase::num_state_type                     = 2;
 int  NavierStokesBase::have_divu                          = 0;
 int  NavierStokesBase::have_dsdt                          = 0;

--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -797,13 +797,9 @@ NavierStokesBase::advance_setup (Real time,
     //
     // Set up state multifabs for the advance.
     //
-amrex::Print() << "/n RAAAAAHHHHH num_state_type " << num_state_type << "\n";
     for (int k = 0; k < num_state_type; k++)
     {
 	bool has_old_data = state[k].hasOldData();
-amrex::Print() << "/n RAAAAAHHHHH k " << k << "\n";
-amrex::Print() << "/n RAAAAAHHHHH has_old_data " << has_old_data << "\n";
-
         state[k].allocOldData();
 	if (! has_old_data) state[k].oldData().setVal(0.0);
         state[k].swapTimeLevels(dt);
@@ -2693,49 +2689,12 @@ NavierStokesBase::post_timestep (int crse_iteration)
         }
     }
 
-/*
-     MultiFab& Savg   = get_new_data(Average_Type);
-      MultiFab& Savg_old   = get_old_data(Average_Type);
-
-      amrex::Print() << std::endl << " DEBUG S_OLD " << std::endl;
-      for (MFIter mfi(Savg_old,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-      {
-      amrex::Print() << Savg_old[mfi];
-      }
-amrex::Print() << std::endl << " DEBUG S_NEW " << std::endl;
-      for (MFIter mfi(Savg,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-      {
-      amrex::Print() << Savg[mfi];
-      }
-*/
-
-
-
-
     if (avg_interval > 0)
     {
       bool flag_init = false;
       const amrex::Real dt_level = parent->dtLevel(level);
       time_average(flag_init, time_avg[level], dt_avg[level], dt_level);
     }
-
-
-/*
-  MultiFab& Savg   = get_new_data(Average_Type);
-      MultiFab& Savg_old   = get_old_data(Average_Type);
-
-      amrex::Print() << std::endl << " DEBUG S_OLD " << std::endl;
-      for (MFIter mfi(Savg_old,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-      {
-      amrex::Print() << Savg_old[mfi];
-      }
-amrex::Print() << std::endl << " DEBUG S_NEW " << std::endl;
-      for (MFIter mfi(Savg,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-      {
-      amrex::Print() << Savg[mfi];
-      }
-*/
-
 
 }
 

--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -2688,6 +2688,7 @@ NavierStokesBase::post_timestep (int crse_iteration)
       const amrex::Real dt_level = parent->dtLevel(level);
       time_average(flag_init, time_avg[level], dt_avg[level], dt_level);
     }
+
 }
 
 //

--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -977,7 +977,7 @@ NavierStokesBase::checkPoint (const std::string& dir,
 			      bool               dump_old)
 {
   AmrLevel::checkPoint(dir, os, how, dump_old);
-/*
+
   if (avg_interval > 0){
     VisMF::IO_Buffer io_buffer(VisMF::IO_Buffer_Size);
 
@@ -1002,7 +1002,7 @@ NavierStokesBase::checkPoint (const std::string& dir,
       TImeAverageFile << NavierStokesBase::time_avg[level] << "\n";
     }
   }
-*/
+
 #ifdef AMREX_PARTICLES
     if (level == 0)
     {


### PR DESCRIPTION
Just put ns.avg_interval = something (>0) to activate the feature.
avg_interval controls the interval of time-steps when a solution is integrated to the average.

The average is dumped in each plotfile.
Do not forget to add "velocity_average" in amr.derive_plot_vars.