### PR TITLE
Feature hook EB geometry

### DIFF
--- a/Source/EBUserDefined.H
+++ b/Source/EBUserDefined.H
@@ -1,0 +1,27 @@
+#ifndef _EBUSERDEFINED_H_
+#define _EBUSERDEFINED_H_
+
+using namespace amrex;
+
+#ifdef AMREX_USE_EB
+#include <AMReX_EB2.H>
+#include <AMReX_EB2_IF.H>
+void
+EBUserDefined(const Geometry& geom,
+              const int required_coarsening_level,
+              const int max_coarsening_level)
+{
+    // ParmParse your geometry parameters
+
+    // Build geometry pieces using EB2::* methods
+
+    // Build your geometry shop using EB2::makeShop
+
+    // Build geom using EB2::Build
+
+    // We shoulnd't be here, copy this file in your run folder
+    // and implement your geometry
+    Abort("In default EBUserDefined function ! Shouldn't be here. Copy and edit this file for your needs");
+}
+#endif
+#endif

--- a/Source/Make.package
+++ b/Source/Make.package
@@ -32,7 +32,7 @@ CEXE_sources += NS_LES.cpp
 CEXE_sources += NS_derive.cpp NS_average.cpp
 CEXE_headers += NS_derive.H
 
-CEXE_headers += Projection.H MacProj.H Diffusion.H NavierStokesBase.H FluxBoxes.H
+CEXE_headers += Projection.H MacProj.H Diffusion.H NavierStokesBase.H FluxBoxes.H EBUserDefined.H
 
 FEXE_headers += PROJECTION_F.H NAVIERSTOKES_F.H 
 

--- a/Source/NS_init_eb2.cpp
+++ b/Source/NS_init_eb2.cpp
@@ -4,6 +4,7 @@ using namespace amrex;
 #ifdef AMREX_USE_EB
 #include <AMReX_EB2.H>
 #include <AMReX_EB2_IF.H>
+#include <EBUserDefined.H>
 #include <NSB_K.H>
 
 #include <AMReX_ParmParse.H>
@@ -66,16 +67,18 @@ void reentrant_profile(std::vector<amrex::RealVect> &points) {
 // called in main before Amr->init(start,stop)
 void
 initialize_EB2 (const Geometry& geom, const int required_coarsening_level,
-		const int max_coarsening_level)
+                const int max_coarsening_level)
 {
     // read in EB parameters
     ParmParse ppeb2("eb2");
     std::string geom_type;
     ppeb2.get("geom_type", geom_type);
 
-#if BL_SPACEDIM > 2
   if (geom_type == "combustor")
   {
+#if (AMREX_SPACEDIM == 2)
+    Abort("geom_type 'combustor' only available in 3D");
+#endif
     ParmParse pp("combustor");
 
     Real fwl;
@@ -124,6 +127,9 @@ initialize_EB2 (const Geometry& geom, const int required_coarsening_level,
   }
   else if (geom_type == "Piston-Cylinder")
   {
+#if (AMREX_SPACEDIM == 2)
+    Abort("geom_type 'Piston-Cylinder' only available in 3D");
+#endif
     EB2::SplineIF Piston;
 
     std::vector<amrex::RealVect> splpts;
@@ -160,6 +166,9 @@ initialize_EB2 (const Geometry& geom, const int required_coarsening_level,
   }
   else if (geom_type == "Line-Piston-Cylinder")
   {
+#if (AMREX_SPACEDIM == 2)
+    Abort("geom_type 'Line-Piston-Cylinder' only available in 3D");
+#endif
     EB2::SplineIF Piston;
     std::vector<amrex::RealVect> lnpts;
     amrex::RealVect p;
@@ -210,7 +219,9 @@ initialize_EB2 (const Geometry& geom, const int required_coarsening_level,
   }
   else if (geom_type == "Inflow-Pipe")
   {
-    
+#if (AMREX_SPACEDIM == 2)
+    Abort("geom_type 'Inflow-Pipe' only available in 3D");
+#endif
     // Initialise parameters
     int direction1 = 2;
     int direction2 = 2;
@@ -273,7 +284,9 @@ initialize_EB2 (const Geometry& geom, const int required_coarsening_level,
   }
   else if (geom_type == "Mixing-Pipe")
   {
-
+#if (AMREX_SPACEDIM == 2)
+    Abort("geom_type 'Mixing-Pipe' only available in 3D");
+#endif
     // Initialise parameters
     int direction = 1;
     Real radius = 0.018;
@@ -313,7 +326,9 @@ initialize_EB2 (const Geometry& geom, const int required_coarsening_level,
   }
   else if (geom_type == "Square-Grid")
   {
-
+#if (AMREX_SPACEDIM == 2)
+    Abort("geom_type 'Square-Grid' only available in 3D");
+#endif
     // Initialise parameters
     Real dim_L0 = 0.08;
     Real ratio_t0_L0_cross = 0.11;
@@ -368,8 +383,10 @@ initialize_EB2 (const Geometry& geom, const int required_coarsening_level,
     EB2::Build(gshop, geom, required_coarsening_level, max_coarsening_level);
 
   }
+  else if (geom_type == "UserDefined") {
+      EBUserDefined(geom, required_coarsening_level, max_coarsening_level);
+  }
   else
-#endif
   {
     EB2::Build(geom, required_coarsening_level, max_coarsening_level);
   }

--- a/Source/NS_init_eb2.cpp
+++ b/Source/NS_init_eb2.cpp
@@ -78,7 +78,7 @@ initialize_EB2 (const Geometry& geom, const int required_coarsening_level,
   {
 #if (AMREX_SPACEDIM == 2)
     Abort("geom_type 'combustor' only available in 3D");
-#endif
+#elif (AMREX_SPACEDIM == 3)
     ParmParse pp("combustor");
 
     Real fwl;
@@ -124,12 +124,13 @@ initialize_EB2 (const Geometry& geom, const int required_coarsening_level,
 
     auto gshop = EB2::makeShop(pr);
     EB2::Build(gshop, geom, required_coarsening_level, max_coarsening_level);
+#endif
   }
   else if (geom_type == "Piston-Cylinder")
   {
 #if (AMREX_SPACEDIM == 2)
     Abort("geom_type 'Piston-Cylinder' only available in 3D");
-#endif
+#elif (AMREX_SPACEDIM == 3)
     EB2::SplineIF Piston;
 
     std::vector<amrex::RealVect> splpts;
@@ -163,12 +164,13 @@ initialize_EB2 (const Geometry& geom, const int required_coarsening_level,
     auto PistonCylinder = EB2::makeUnion(revolvePiston, cylinder);
     auto gshop = EB2::makeShop(PistonCylinder);
     EB2::Build(gshop, geom, required_coarsening_level, max_coarsening_level);
+#endif
   }
   else if (geom_type == "Line-Piston-Cylinder")
   {
 #if (AMREX_SPACEDIM == 2)
     Abort("geom_type 'Line-Piston-Cylinder' only available in 3D");
-#endif
+#elif (AMREX_SPACEDIM == 3)
     EB2::SplineIF Piston;
     std::vector<amrex::RealVect> lnpts;
     amrex::RealVect p;
@@ -216,12 +218,13 @@ initialize_EB2 (const Geometry& geom, const int required_coarsening_level,
     auto PistonCylinder = EB2::makeUnion(revolvePiston, cylinder);
     auto gshop = EB2::makeShop(PistonCylinder);
     EB2::Build(gshop, geom, required_coarsening_level, max_coarsening_level);
+#endif
   }
   else if (geom_type == "Inflow-Pipe")
   {
 #if (AMREX_SPACEDIM == 2)
     Abort("geom_type 'Inflow-Pipe' only available in 3D");
-#endif
+#elif (AMREX_SPACEDIM == 3)
     // Initialise parameters
     int direction1 = 2;
     int direction2 = 2;
@@ -280,13 +283,13 @@ initialize_EB2 (const Geometry& geom, const int required_coarsening_level,
     int max_level_here = 0;
     int max_coarsening_level = 100;
     EB2::Build(gshop, geom, required_coarsening_level, max_coarsening_level);
-
+#endif
   }
   else if (geom_type == "Mixing-Pipe")
   {
 #if (AMREX_SPACEDIM == 2)
     Abort("geom_type 'Mixing-Pipe' only available in 3D");
-#endif
+#elif (AMREX_SPACEDIM == 3)
     // Initialise parameters
     int direction = 1;
     Real radius = 0.018;
@@ -322,13 +325,13 @@ initialize_EB2 (const Geometry& geom, const int required_coarsening_level,
     int max_level_here = 0;
     int max_coarsening_level = 100;
     EB2::Build(gshop, geom, required_coarsening_level, max_coarsening_level);
-
+#endif
   }
   else if (geom_type == "Square-Grid")
   {
 #if (AMREX_SPACEDIM == 2)
     Abort("geom_type 'Square-Grid' only available in 3D");
-#endif
+#elif (AMREX_SPACEDIM == 3)
     // Initialise parameters
     Real dim_L0 = 0.08;
     Real ratio_t0_L0_cross = 0.11;
@@ -381,7 +384,7 @@ initialize_EB2 (const Geometry& geom, const int required_coarsening_level,
     int max_level_here = 0;
     int max_coarsening_level = 100;
     EB2::Build(gshop, geom, required_coarsening_level, max_coarsening_level);
-
+#endif
   }
   else if (geom_type == "UserDefined") {
       EBUserDefined(geom, required_coarsening_level, max_coarsening_level);


### PR DESCRIPTION
Add a hook to NS_init_EB to enable the definition of a user-defined geometry.
The file EBUserDefined.H contains a dummy version that'll be overwritten by copying this file in your local folder.