### PR TITLE
Reduce compiler warnings

### DIFF
--- a/Source/FluxBoxes.H
+++ b/Source/FluxBoxes.H
@@ -12,7 +12,7 @@ public:
     explicit FluxBoxes (const amrex::AmrLevel* amr_level, int nvar=1, int nghost=0)
 	: data(0) { define(amr_level, nvar, nghost); }
 
-    ~FluxBoxes () { clear(); };
+    ~FluxBoxes () { clear(); }
 
     amrex::MultiFab** define (const amrex::AmrLevel* amr_level, int nvar=1, int nghost=0);
 

--- a/Source/NS_LES.cpp
+++ b/Source/NS_LES.cpp
@@ -96,7 +96,7 @@ NavierStokesBase::calc_mut_LES(MultiFab* mu_LES[BL_SPACEDIM], const Real time)
      tensorop.setLevelBC(0, &Uvel);
   }
               
-  const int dim_fluxes = pow(AMREX_SPACEDIM,2);
+  const int dim_fluxes = static_cast<int>(pow(AMREX_SPACEDIM,2));
   
   FluxBoxes fb(this,dim_fluxes);
   MultiFab** tensorflux = fb.get();

--- a/Source/NS_derive.cpp
+++ b/Source/NS_derive.cpp
@@ -10,7 +10,7 @@ namespace derive_functions
 {
   void der_vel_avg (const Box& bx, FArrayBox& derfab, int dcomp, int ncomp,
 		    const FArrayBox& datfab, const Geometry& /*geomdata*/,
-		    Real time, const int* /*bcrec*/, int level)
+		    Real /*time*/, const int* /*bcrec*/, int level)
 
   {
     AMREX_ASSERT(derfab.box().contains(bx));

--- a/Source/NS_getForce.cpp
+++ b/Source/NS_getForce.cpp
@@ -46,7 +46,7 @@ NavierStokesBase::getForce (FArrayBox&       force,
                             const FArrayBox& Vel,
                             const FArrayBox& Scal,
                             int              scalScomp,
-                            const MFIter&    mfi)
+                            const MFIter&    /*mfi*/)
 {
 
    const Real* VelDataPtr  = Vel.dataPtr();

--- a/Source/NS_util.cpp
+++ b/Source/NS_util.cpp
@@ -9,7 +9,7 @@ namespace amrex {
 
   Vector<Real>
   VectorMax(const Vector<const MultiFab *>& mfs,
-            const IntVect&                  tilesize,
+            const IntVect&                  /*tilesize*/,
             int                             sComp,
             int                             nComp,
             int                             nGrow)
@@ -32,7 +32,7 @@ namespace amrex {
 
   Vector<Real>
   VectorMaxAbs(const Vector<const MultiFab *>& mfs,
-               const IntVect&                  tilesize,
+               const IntVect&                  /*tilesize*/,
                int                             sComp,
                int                             nComp,
                int                             nGrow)
@@ -55,7 +55,7 @@ namespace amrex {
 
   Vector<Real>
   VectorMin(const Vector<const MultiFab *>& mfs,
-            const IntVect&                  tilesize,
+            const IntVect&                  /*tilesize*/,
             int                             sComp,
             int                             nComp,
             int                             nGrow)

--- a/Source/NavierStokesBase.H
+++ b/Source/NavierStokesBase.H
@@ -218,9 +218,9 @@ public:
 
     static int DoTrac2();
 
-    static bool GodunovUsePPM () {return godunov_use_ppm;};
-    static bool GodunovUseForcesInTrans () {return godunov_use_forces_in_trans;};
-    static int  GodunovHypgrow () {return godunov_hyp_grow;};
+    static bool GodunovUsePPM () {return godunov_use_ppm;}
+    static bool GodunovUseForcesInTrans () {return godunov_use_forces_in_trans;}
+    static int  GodunovHypgrow () {return godunov_hyp_grow;}
 
     //////////////////////////////////////////////////////////////////
 
@@ -472,7 +472,7 @@ public:
     //
     static void Initialize_specific (){
       amrex::Abort("NavierStokesBase::Initialize_specific: This function must be implemented in derived class");
-    };
+    }
     static void Finalize ();
     //
     // Check for RZ geometry

--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -1683,7 +1683,6 @@ NavierStokesBase::level_projector (Real dt,
 
     int        crse_dt_ratio  = (level > 0) ? parent->nCycle(level) : -1;
     const Real cur_pres_time  = state[Press_Type].curTime();
-    const Real prev_pres_time = state[Press_Type].prevTime();
 
     projector->level_project(level,time,dt,cur_pres_time,
                              geom,U_old,U_new,P_old,P_new,
@@ -1765,13 +1764,6 @@ NavierStokesBase::level_sync (int crse_iteration)
     // The multilevel projection.  This computes the projection and
     // adds in its contribution to levels (level) and (level+1).
     //
-    Real  cur_crse_pres_time = state[Press_Type].curTime();
-    Real prev_crse_pres_time = state[Press_Type].prevTime();
-
-    NavierStokesBase& fine_lev   = getLevel(level+1);
-    Real  cur_fine_pres_time = fine_lev.state[Press_Type].curTime();
-    Real prev_fine_pres_time = fine_lev.state[Press_Type].prevTime();
-
     projector->MLsyncProject(level,pres,vel,cc_rhs_crse,
 			     pres_fine,v_fine,cc_rhs_fine,
 			     Rh,rho_fine,Vsync,V_corr,
@@ -3223,7 +3215,6 @@ NavierStokesBase::velocity_advection (Real dt)
         }
     }
 
-    const int   finest_level   = parent->finestLevel();
     const Real  prev_time      = state[State_Type].prevTime();
 
     // FIXME? pretty sure this should be nghost_force & only mult by dsdt for godunov
@@ -3294,7 +3285,6 @@ NavierStokesBase::velocity_advection (Real dt)
         {
 
             auto const force_bx = U_mfi.growntilebox(nghost_force()); // Box for forcing term
-            auto const state_bx = U_mfi.growntilebox(nghost_state()); // Box for state   terms
 
             if (getForceVerbose)
             {

--- a/Source/Projection.cpp
+++ b/Source/Projection.cpp
@@ -1250,7 +1250,7 @@ Projection::ConvertUnew( FArrayBox &Unew, FArrayBox &Uold, Real alpha,
 //
 void
 Projection::scaleVar (MultiFab*       sig,
-                      int             sig_nghosts,
+                      int             /*sig_nghosts*/,
                       MultiFab*       vel,
                       int             level)
 {
@@ -1368,7 +1368,7 @@ Projection::scaleVar (MultiFab*       sig,
 //
 void
 Projection::rescaleVar (MultiFab*       sig,
-                        int             sig_nghosts,
+                        int             /*sig_nghosts*/,
                         MultiFab*       vel,
                         int             level)
 {
@@ -1872,17 +1872,17 @@ Projection::set_outflow_bcs (int        which_call,
 }
 
 void
-Projection::set_outflow_bcs_at_level (int          which_call,
+Projection::set_outflow_bcs_at_level (int          /*which_call*/,
                                       int          lev,
                                       int          c_lev,
                                       Box*         state_strip,
                                       Orientation* outFacesAtThisLevel,
                                       int          numOutFlowFaces,
                                       const Vector<MultiFab*>&  phi,
-                                      MultiFab*    Vel_in,
-                                      MultiFab*    Divu_in,
+                                      MultiFab*    /*Vel_in*/,
+                                      MultiFab*    /*Divu_in*/,
                                       MultiFab*    Sig_in,
-                                      int          have_divu,
+                                      int          /*have_divu*/,
                                       Real         gravity)
 {
     AMREX_ASSERT(dynamic_cast<NavierStokesBase*>(LevelData[lev]) != nullptr);

--- a/Source/SyncRegister.cpp
+++ b/Source/SyncRegister.cpp
@@ -559,7 +559,7 @@ SyncRegister::FineAdd (MultiFab& Sync_resid_fine, const Geometry& crse_geom, Rea
         const Box& finebox  = mfi.validbox();
         GpuArray<int,3> flo = finebox.loVect3d();
         GpuArray<int,3> fhi = finebox.hiVect3d();
-        ParallelFor(mfi.tilebox(), [finefab_a,flo,fhi,twoThirds]
+        ParallelFor(mfi.tilebox(), [finefab_a,flo,fhi]
         AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
 #if AMREX_SPACEDIM == 2


### PR DESCRIPTION
Remove most of the compiler warnings pertaining to unused variables, shadowed variables or pedantic extra ;
I didn't remove but simply commented out some function unused arguments because I was unsure of their previous usage.