### PR TITLE
Fix OOB access on coarsedata in NavierStokesBase::SyncInterp()

### DIFF
--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -3101,6 +3101,7 @@ NavierStokesBase::SyncInterp (MultiFab&      CrseSync,
 
             if ( scale_coarse ) {
                 amrex::ParallelFor(cbx, num_comp, [coarsedata,dt_clev]
+                AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept
                 {
                     coarsedata(i,j,k,n) /= dt_clev;
                 });

--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -3069,17 +3069,20 @@ NavierStokesBase::SyncInterp (MultiFab&      CrseSync,
             auto const& finedata    = fdata.array();
             auto const& coarsedata  = cdata.array();
             int scale_coarse = (interpolater == &protected_interp) ? 1 : 0;
-            amrex::ParallelFor(bx, num_comp, [finedata,coarsedata,dt_clev, scale_coarse,ratio]
+            amrex::ParallelFor(bx, num_comp, [finedata,dt_clev]
             AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept
             {
                finedata(i,j,k,n) *= dt_clev;
-               if ( scale_coarse ) {
-                   int ii = i/ratio[0];
-                   int jj = j/ratio[1];
-                   int kk = (AMREX_SPACEDIM == 3) ? k/ratio[2] : k;
-                   coarsedata(ii,jj,kk,n) *= dt_clev;
-               }
             });
+
+            if ( scale_coarse ) {
+                amrex::ParallelFor(cbx, num_comp, [coarsedata,dt_clev]
+                AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept
+                {
+                    coarsedata(i,j,k,n) *= dt_clev;
+                });
+            }
+
 
             if (interpolater == &protected_interp)
             {
@@ -3090,17 +3093,20 @@ NavierStokesBase::SyncInterp (MultiFab&      CrseSync,
             }
 
             auto const& fsync       = FineSync.array(mfi,dest_comp);
-            amrex::ParallelFor(bx, num_comp, [finedata,fsync,coarsedata,dt_clev,scale_coarse,ratio]
+            amrex::ParallelFor(bx, num_comp, [finedata,fsync]
             AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept
             {
-               if ( scale_coarse ) {
-                   int ii = i/ratio[0];
-                   int jj = j/ratio[1];
-                   int kk = (AMREX_SPACEDIM == 3) ? k/ratio[2] : k;
-                   coarsedata(ii,jj,kk,n) /= dt_clev;
-               }
                fsync(i,j,k,n) += finedata(i,j,k,n);
             });
+
+            if ( scale_coarse ) {
+                amrex::ParallelFor(cbx, num_comp, [coarsedata,dt_clev]
+                {
+                    coarsedata(i,j,k,n) /= dt_clev;
+                });
+            }
+
+
          }
          else
          {


### PR DESCRIPTION
When the `CellConstProt_T` interpolater enum is in use for `NavierStokesBase::SyncInterp(which_interp)`, the code segfaults with an out-of-bounds error due to accesses on `coarsedata` using the same grid as `finedata`. This PR tries to fix that. Tested on CPU (local) using the "bubble" inputfile in Exec/run2d.