### PR TITLE
Set Tracer, Tracer2 and Temp before they are used in Initialize_specific

### DIFF
--- a/Exec/benchmarks/ViscBench2d.cpp
+++ b/Exec/benchmarks/ViscBench2d.cpp
@@ -197,8 +197,10 @@ main (int   argc,
         WritePlotFile(dataE, amrDataI, exFile, verbose);
 
 
-    for (int iLevel = 0; iLevel <= finestLevel; ++iLevel)
+    for (int iLevel = 0; iLevel <= finestLevel; ++iLevel) {
 	delete error[iLevel];
+        delete dataE[iLevel];
+    }
 
     //
     // This calls ParallelDescriptor::EndParallel() and exit()

--- a/Source/NS_setup.cpp
+++ b/Source/NS_setup.cpp
@@ -220,16 +220,6 @@ NavierStokes::variableSetUp ()
     Initialize();
 
     BCRec bc;
-    //
-    // Set number of state variables.
-    //
-    NUM_STATE = Density + 1;
-    Tracer = NUM_STATE++;
-    if (do_trac2)
-        Tracer2 = NUM_STATE++;
-    if (do_temp)
-        Temp = NUM_STATE++;
-    NUM_SCALARS = NUM_STATE - Density;
 
     //
     // **************  DEFINE VELOCITY VARIABLES  ********************

--- a/Source/NavierStokes.cpp
+++ b/Source/NavierStokes.cpp
@@ -40,6 +40,17 @@ NavierStokes::Initialize ()
 
     NavierStokesBase::Initialize();
 
+    //
+    // Set number of state variables.
+    //
+    NUM_STATE = Density + 1;
+    Tracer = NUM_STATE++;
+    if (do_trac2)
+        Tracer2 = NUM_STATE++;
+    if (do_temp)
+        Temp = NUM_STATE++;
+    NUM_SCALARS = NUM_STATE - Density;
+
     NavierStokes::Initialize_specific();
 
     amrex::ExecOnFinalize(NavierStokes::Finalize);


### PR DESCRIPTION

And fix a memory leak in benchmarks/ViscBench2d.cpp.