### PR TITLE
Remove Diffusion::visc_coef array and clean up of NavierStokes initialization.

### DIFF
--- a/Source/Diffusion.H
+++ b/Source/Diffusion.H
@@ -41,8 +41,7 @@ public:
                Diffusion*                coarser,
                int                       num_state,
                amrex::FluxRegister*      Viscflux_reg,
-               const amrex::Vector<int>&  _is_diffusive,
-               const amrex::Vector<amrex::Real>& _visc_coef);
+               const amrex::Vector<int>&  _is_diffusive);
 
     ~Diffusion ();
 
@@ -258,7 +257,6 @@ protected:
     //
     static int         scale_abec;
     static amrex::Vector<int>  is_diffusive;    // Does variable diffuse?
-    static amrex::Vector<amrex::Real> visc_coef;       // Const coef viscosity terms
     static int         verbose;
     static amrex::Real        visc_tol;
 

--- a/Source/Diffusion.cpp
+++ b/Source/Diffusion.cpp
@@ -49,13 +49,11 @@ int         Diffusion::max_order;
 int         Diffusion::scale_abec;
 int         Diffusion::tensor_max_order;
 
-Vector<Real> Diffusion::visc_coef;
 Vector<int>  Diffusion::is_diffusive;
 
 void
 Diffusion::Finalize ()
 {
-    visc_coef.clear();
     is_diffusive.clear();
 
     initialized = false;
@@ -66,8 +64,7 @@ Diffusion::Diffusion (Amr*               Parent,
                       Diffusion*         Coarser,
                       int                num_state,
                       FluxRegister*      Viscflux_reg,
-                      const Vector<int>&  _is_diffusive,
-                      const Vector<Real>& _visc_coef)
+                      const Vector<int>&  _is_diffusive)
     :
     parent(Parent),
     navier_stokes(Caller),
@@ -121,25 +118,16 @@ Diffusion::Diffusion (Amr*               Parent,
 
         do_reflux = (do_reflux ? 1 : 0);
 
-        const int n_visc = _visc_coef.size();
         const int n_diff = _is_diffusive.size();
 
         if (n_diff < NUM_STATE)
             amrex::Abort("Diffusion::Diffusion(): is_diffusive array is not long enough");
 
-        if (n_visc < NUM_STATE)
-            amrex::Abort("Diffusion::Diffusion(): TOO FEW diffusion coeffs were given! One for viscosity and one for each tracer are required.");
-
-        if (n_visc > NUM_STATE)
-            amrex::Abort("Diffusion::Diffusion(): TOO MANY diffusion coeffs were given! One for viscosity and one for each tracer are required.");
-
-        visc_coef.resize(NUM_STATE);
         is_diffusive.resize(NUM_STATE);
 
         for (int i = 0; i < NUM_STATE; i++)
         {
             is_diffusive[i] = _is_diffusive[i];
-            visc_coef[i] = _visc_coef[i];
         }
 
         echo_settings();
@@ -197,10 +185,6 @@ Diffusion::echo_settings () const
         amrex::Print() << "   is_diffusive =";
         for (int i =0; i < NUM_STATE; i++)
             amrex::Print() << "  " << is_diffusive[i];
-
-        amrex::Print() << "\n   visc_coef =";
-        for (int i = 0; i < NUM_STATE; i++)
-            amrex::Print() << "  " << visc_coef[i];
 
         amrex::Print() << '\n';
     }

--- a/Source/NavierStokes.H
+++ b/Source/NavierStokes.H
@@ -183,7 +183,8 @@ protected:
                            int                 ngrow) override;
 
     static void Initialize ();   // Read input file
-    static void Initialize_specific ();   // Read input file specific to IAMR
+    static void Initialize_bcs ();
+    static void Initialize_diffusivities ();
     static void Finalize ();
 
 private:

--- a/Source/NavierStokesBase.H
+++ b/Source/NavierStokesBase.H
@@ -467,12 +467,6 @@ public:
     // Read input file
     //
     static void Initialize ();
-    //
-    // Read input file specific to IAMR or PLM
-    //
-    static void Initialize_specific (){
-      amrex::Abort("NavierStokesBase::Initialize_specific: This function must be implemented in derived class");
-    }
     static void Finalize ();
     //
     // Check for RZ geometry

--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -326,7 +326,7 @@ NavierStokesBase::NavierStokesBase (Amr&            papa,
     //
     diffusion = new Diffusion(parent,this,
                               (level > 0) ? getLevel(level-1).diffusion : 0,
-                              NUM_STATE,viscflux_reg,is_diffusive,visc_coef);
+                              NUM_STATE,viscflux_reg,is_diffusive);
     //
     // Allocate the storage for variable viscosity and diffusivity
     //
@@ -2563,7 +2563,7 @@ NavierStokesBase::restart (Amr&          papa,
 
     diffusion = new Diffusion(parent, this,
                               (level > 0) ? getLevel(level-1).diffusion : 0,
-                              NUM_STATE, viscflux_reg,is_diffusive, visc_coef);
+                              NUM_STATE, viscflux_reg,is_diffusive);
     //
     // Allocate the storage for variable viscosity and diffusivity
     //


### PR DESCRIPTION
Remove Diffusion::visc_coef because it's not used in Diffusion.
Move checks on visc_coef from Diffusion to NavierStokes (which actually uses visc_coef).
Remove NavierStokesBase::Initialize_specific. 
Minor clean up of NavierStokes Initialize for clarity and to quiet compiler warnings.