### PR TITLE
Update create umac grown

### DIFF
--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -1109,34 +1109,6 @@ NavierStokesBase::create_umac_grown (int nGrow,
        PhysBCFunct<GpuBndryFuncFab<umacFill>> fine_bndry_func(*fine_geom, bcrec, umacFill{});
        Array<PhysBCFunct<GpuBndryFuncFab<umacFill>>,AMREX_SPACEDIM> fbndyFuncArr = {AMREX_D_DECL(fine_bndry_func,fine_bndry_func,fine_bndry_func)};
 
-//Check single comp???
-//        // Squirel away the interior umac
-//        Array<MultiFab,AMREX_SPACEDIM> u_mac_tmp;
-//        for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
-//           u_mac_tmp[idim].define(u_mac_fine[idim]->boxArray(), u_mac_fine[idim]->DistributionMap(),
-//                                  u_mac_fine[idim]->nComp(), u_mac_fine[idim]->nGrow());
-//           MultiFab::Copy(u_mac_tmp[idim], *u_mac_fine[idim], 0, 0, 1, 0);
-//        }
-
-// // See how single comp FPTL does...
-//        for (int d=0; d<AMREX_SPACEDIM; ++d)
-//        {
-//        	   std::cout<<"Calling FP2L "<<d<<std::endl;
-//        	   Real time = 0.;
-//        	   FillPatchTwoLevels(u_mac_tmp[d], IntVect(nGrow), time,
-//        	   		      {u_mac_crse[d]}, {time},
-//        	   		      {&u_mac_tmp[d]}, {time},
-//        	   		      0, 0, 1,
-//        	   		      *crse_geom, *fine_geom,
-//        	   		      crse_bndry_func, 0, fine_bndry_func, 0,
-//        	   		      crse_ratio, mapper, bcrec, 0);
-//        }
-//        std::cout<<"Writing FPSL MFs"<<std::endl;
-//        VisMF::Write(u_mac_tmp[0],"umac_sc");
-//        VisMF::Write(u_mac_tmp[1],"vmac_sc");
-//        std::cout<<"done writing FPSL MFs"<<std::endl;
-
-
        // Use piecewise constant interpolation in time, so create dummy variable for time
        Real dummy = 0.;
        FillPatchTwoLevels(u_mac_fine, IntVect(nGrow), dummy,

--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -12,7 +12,7 @@
 #include <NAVIERSTOKES_F.H>
 #include <NSB_K.H>
 #include <NS_util.H>
-#include <hydro_utils.H>
+#include <AMReX_FillPatchUtil.H>
 
 #include <hydro_mol.H>
 #include <hydro_godunov.H>
@@ -29,7 +29,10 @@
 
 using namespace amrex;
 
-struct DummyFill           // Set 0.0 on EXT_DIR, nothing otherwise.
+//
+// Set external dirichlet BC to zero
+//
+struct HomExtDirFill
 {
     AMREX_GPU_DEVICE
     void operator() (const IntVect& iv, Array4<Real> const& dest,
@@ -53,6 +56,38 @@ struct DummyFill           // Set 0.0 on EXT_DIR, nothing otherwise.
        }
     }
 };
+
+//
+// A dummy function because FillPatch requires something to exist for filling dirichlet boundary conditions,
+// even if we know we cannot have an ext_dir BC.
+// u_mac BCs are only either periodic (INT_DIR) or first order extrapolation (FOEXTRAP).
+//
+struct umacFill
+{
+    AMREX_GPU_DEVICE
+    void operator()(
+       const amrex::IntVect& /*iv*/,
+       amrex::Array4<amrex::Real> const& /*dummy*/,
+       const int /*dcomp*/,
+       const int numcomp,
+       amrex::GeometryData const& /*geom*/,
+       const amrex::Real /*time*/,
+       const amrex::BCRec* bcr,
+       const int bcomp,
+       const int /*orig_comp*/) const
+    {
+        // Abort if this function is expected to fill an ext_dir BC.
+        for (int n = bcomp; n < bcomp+numcomp; ++n) {
+            const amrex::BCRec& bc = bcr[n];
+            if ( AMREX_D_TERM(   bc.lo(0) == amrex::BCType::ext_dir || bc.hi(0) == amrex::BCType::ext_dir,
+                              || bc.lo(1) == amrex::BCType::ext_dir || bc.hi(1) == amrex::BCType::ext_dir,
+                              || bc.lo(2) == amrex::BCType::ext_dir || bc.hi(2) == amrex::BCType::ext_dir ) ) {
+               amrex::Abort("NavierStokesBase::umacFill: umac should not have BCType::ext_dir");
+            }
+        }
+    }
+};
+
 
 BCRec       NavierStokesBase::phys_bc;
 Projection* NavierStokesBase::projector     = 0;
@@ -1031,30 +1066,95 @@ NavierStokesBase::create_mac_rhs (MultiFab& rhs, int nGrow, Real time, Real dt)
 
 void
 NavierStokesBase::create_umac_grown (int nGrow,
-                                     const MultiFab* a_divu)
+                                     const MultiFab* /*a_divu*/)
 {
 
-  Array<MultiFab*, AMREX_SPACEDIM> umac_crse;
-  Array<MultiFab*, AMREX_SPACEDIM> umac_fine;
+    Array<MultiFab*, AMREX_SPACEDIM> u_mac_crse;
+    Array<MultiFab*, AMREX_SPACEDIM> u_mac_fine;
 
-  if ( level > 0 )
-  {
-    AMREX_D_TERM(umac_crse[0] = &getLevel(level-1).u_mac[0];,
-                 umac_crse[1] = &getLevel(level-1).u_mac[1];,
-                 umac_crse[2] = &getLevel(level-1).u_mac[2];);
-  }
-  AMREX_D_TERM(umac_fine[0] = &u_mac[0];,
-               umac_fine[1] = &u_mac[1];,
-               umac_fine[2] = &u_mac[2];);
+    AMREX_D_TERM(u_mac_fine[0] = &u_mac[0];,
+                 u_mac_fine[1] = &u_mac[1];,
+                 u_mac_fine[2] = &u_mac[2];);
 
-  // Check divu: if not nullptr, we need at least one ghost cell
-  int nGrow_divu = (a_divu != nullptr) ? a_divu->nGrow() : 1;
-  AMREX_ASSERT(nGrow_divu >= 1);
+    Geometry *crse_geom = (level==0) ? nullptr : &getLevel(level-1).geom;
+    Geometry *fine_geom = &geom;
 
-  Geometry *crse_geom = (level==0) ? nullptr : &getLevel(level-1).geom;
-  Geometry *fine_geom = &geom;
-  HydroUtils::create_constrained_umac_grown (level, nGrow, grids, crse_geom, fine_geom,
-                                             umac_crse, umac_fine, a_divu, crse_ratio);
+    if ( level > 0)
+    {
+        AMREX_D_TERM(u_mac_crse[0] = &getLevel(level-1).u_mac[0];,
+                     u_mac_crse[1] = &getLevel(level-1).u_mac[1];,
+                     u_mac_crse[2] = &getLevel(level-1).u_mac[2];);
+
+       // Divergence preserving interp
+       Interpolater* mapper = &face_divfree_interp;
+       // This one most closely matches up with old create umac grown
+       //Interpolater* mapper = &face_linear_interp;
+
+       // Set BCRec for Umac
+       Vector<BCRec> bcrec(1);
+       for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
+            if (crse_geom->isPeriodic(idim)) {
+               bcrec[0].setLo(idim,BCType::int_dir);
+               bcrec[0].setHi(idim,BCType::int_dir);
+            } else {
+               bcrec[0].setLo(idim,BCType::foextrap);
+               bcrec[0].setHi(idim,BCType::foextrap);
+            }
+       }
+       Array<Vector<BCRec>,AMREX_SPACEDIM> bcrecArr = {AMREX_D_DECL(bcrec,bcrec,bcrec)};
+
+       PhysBCFunct<GpuBndryFuncFab<umacFill>> crse_bndry_func(*crse_geom, bcrec, umacFill{});
+       Array<PhysBCFunct<GpuBndryFuncFab<umacFill>>,AMREX_SPACEDIM> cbndyFuncArr = {AMREX_D_DECL(crse_bndry_func,crse_bndry_func,crse_bndry_func)};
+
+       PhysBCFunct<GpuBndryFuncFab<umacFill>> fine_bndry_func(*fine_geom, bcrec, umacFill{});
+       Array<PhysBCFunct<GpuBndryFuncFab<umacFill>>,AMREX_SPACEDIM> fbndyFuncArr = {AMREX_D_DECL(fine_bndry_func,fine_bndry_func,fine_bndry_func)};
+
+//Check single comp???
+//        // Squirel away the interior umac
+//        Array<MultiFab,AMREX_SPACEDIM> u_mac_tmp;
+//        for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
+//           u_mac_tmp[idim].define(u_mac_fine[idim]->boxArray(), u_mac_fine[idim]->DistributionMap(),
+//                                  u_mac_fine[idim]->nComp(), u_mac_fine[idim]->nGrow());
+//           MultiFab::Copy(u_mac_tmp[idim], *u_mac_fine[idim], 0, 0, 1, 0);
+//        }
+
+// // See how single comp FPTL does...
+//        for (int d=0; d<AMREX_SPACEDIM; ++d)
+//        {
+//        	   std::cout<<"Calling FP2L "<<d<<std::endl;
+//        	   Real time = 0.;
+//        	   FillPatchTwoLevels(u_mac_tmp[d], IntVect(nGrow), time,
+//        	   		      {u_mac_crse[d]}, {time},
+//        	   		      {&u_mac_tmp[d]}, {time},
+//        	   		      0, 0, 1,
+//        	   		      *crse_geom, *fine_geom,
+//        	   		      crse_bndry_func, 0, fine_bndry_func, 0,
+//        	   		      crse_ratio, mapper, bcrec, 0);
+//        }
+//        std::cout<<"Writing FPSL MFs"<<std::endl;
+//        VisMF::Write(u_mac_tmp[0],"umac_sc");
+//        VisMF::Write(u_mac_tmp[1],"vmac_sc");
+//        std::cout<<"done writing FPSL MFs"<<std::endl;
+
+
+       // Use piecewise constant interpolation in time, so create dummy variable for time
+       Real dummy = 0.;
+       FillPatchTwoLevels(u_mac_fine, IntVect(nGrow), dummy,
+			  {u_mac_crse}, {dummy},
+			  {u_mac_fine}, {dummy},
+			  0, 0, 1,
+			  *crse_geom, *fine_geom,
+			  cbndyFuncArr, 0, fbndyFuncArr, 0,
+			  crse_ratio, mapper, bcrecArr, 0);
+    }
+    else
+    {
+        // Fill boundary for all the levels
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
+        {
+            u_mac_fine[idim]->FillBoundary(fine_geom->periodicity());
+        }
+    }
 }
 
 void
@@ -3000,7 +3100,7 @@ NavierStokesBase::SyncInterp (MultiFab&      CrseSync,
     ///////
 
     // tiling may not be needed here, but what the hey
-    GpuBndryFuncFab<DummyFill> gpu_bndry_func(DummyFill{});
+    GpuBndryFuncFab<HomExtDirFill> gpu_bndry_func(HomExtDirFill{});
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif


### PR DESCRIPTION
Make new `NSB::create_umac_grown` that uses `FillPatchTwoLevels`. 

This fixes an error wherein the valid fine face values at the coarse-fine interface were not being used in the computation of fine ghost cell values. Previously, IAMR used `HydroUtils::create_constrained_umac_grown` which relies on `InterpFromCoarseLevel` which uses interpolated coarse values at the coarse-fine interface rather than the valid fine data that exists there in this case. Differences are likely subtle, as `create_constrained_umac_grown` makes further corrections after the interpolation.