### PR TITLE
Fix mac sync

### DIFF
--- a/Source/MacProj.cpp
+++ b/Source/MacProj.cpp
@@ -689,24 +689,9 @@ MacProj::mac_sync_compute (int                   level,
                         }
 
                     }
-                    else  // Scalars
+                    else  // Scalars. Reconstruct forcing terms as in scalar_advection
                     {
                         auto const& visc = scal_visc_terms[Smfi].const_array(comp-AMREX_SPACEDIM);
-                        // auto const& S    = Smf.const_array(Smfi,comp);
-                        // auto const& divu = divu_fp -> const_array(Smfi);
-                        // amrex::ParallelFor(gbx, [tf, visc, S, divu]
-                        // AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-                        // {
-			//     // FIXME??? I think this S divU is a vestige of the old
-			//     // Godunov that only computed a convective term, and the
-			//     // adjustement for conservative was here. But now all this
-			//     // should be contained in Godunov...
-			//     // Or maybe the deal was that the tracer was always convective
-			//     // but could choose to do conservative differencing and then
-			//     // use S divU to get back to a passively advected scalar???
-                        //     tf(i,j,k) += visc(i,j,k) - S(i,j,k) * divu(i,j,k);
-                        // });
-
 			auto const& rho = Smf.const_array(Smfi,Density); 
 			
 			if ( NavierStokesBase::do_temp && comp==NavierStokesBase::Temp )

--- a/Source/MacProj.cpp
+++ b/Source/MacProj.cpp
@@ -692,49 +692,49 @@ MacProj::mac_sync_compute (int                   level,
                     else  // Scalars. Reconstruct forcing terms as in scalar_advection
                     {
                         auto const& visc = scal_visc_terms[Smfi].const_array(comp-AMREX_SPACEDIM);
-			auto const& rho = Smf.const_array(Smfi,Density); 
-			
-			if ( NavierStokesBase::do_temp && comp==NavierStokesBase::Temp )
-			{
-			    //
-			    // Solving
-			    //   dT/dt + U dot del T = ( del dot lambda grad T + H_T ) / (rho c_p)
-			    // with tforces = H_T/c_p (since it's always density-weighted), and
-			    // visc = del dot mu grad T, where mu = lambda/c_p
-			    //
-			    amrex::ParallelFor(gbx, [tf, visc, rho]
+                        auto const& rho = Smf.const_array(Smfi,Density);
+
+                        if ( NavierStokesBase::do_temp && comp==NavierStokesBase::Temp )
+                        {
+                            //
+                            // Solving
+                            //   dT/dt + U dot del T = ( del dot lambda grad T + H_T ) / (rho c_p)
+                            // with tforces = H_T/c_p (since it's always density-weighted), and
+                            // visc = del dot mu grad T, where mu = lambda/c_p
+                            //
+                            amrex::ParallelFor(gbx, [tf, visc, rho]
                             AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-			    { tf(i,j,k) = ( tf(i,j,k) + visc(i,j,k) ) / rho(i,j,k); });
-			}
-			else
-			{
-			    if (advectionType[comp] == Conservative)
-			    {
-				//
-				// For tracers, Solving
-				//   dS/dt + del dot (U S) = del dot beta grad (S/rho) + rho H_q
-				// where S = rho q, q is a concentration
-				// tforces = rho H_q (since it's always density-weighted)
-				// visc = del dot beta grad (S/rho)
-				//
-				amrex::ParallelFor(gbx, [tf, visc]
+                            { tf(i,j,k) = ( tf(i,j,k) + visc(i,j,k) ) / rho(i,j,k); });
+                        }
+                        else
+                        {
+                            if (advectionType[comp] == Conservative)
+                            {
+                                //
+                                // For tracers, Solving
+                                //   dS/dt + del dot (U S) = del dot beta grad (S/rho) + rho H_q
+                                // where S = rho q, q is a concentration
+                                // tforces = rho H_q (since it's always density-weighted)
+                                // visc = del dot beta grad (S/rho)
+                                //
+                                amrex::ParallelFor(gbx, [tf, visc]
                                 AMREX_GPU_DEVICE (int i, int j, int k ) noexcept
                                 { tf(i,j,k) += visc(i,j,k); });
-			    }
-			    else
-			    {
-				//
-				// Solving
-				//   dS/dt + U dot del S = del dot beta grad S + H_q
-				// where S = q, q is a concentration
-				// tforces = rho H_q (since it's always density-weighted)
-				// visc = del dot beta grad S
-				//
-				amrex::ParallelFor(gbx, [tf, visc, rho]
+                            }
+                            else
+                            {
+                                //
+                                // Solving
+                                //   dS/dt + U dot del S = del dot beta grad S + H_q
+                                // where S = q, q is a concentration
+                                // tforces = rho H_q (since it's always density-weighted)
+                                // visc = del dot beta grad S
+                                //
+                                amrex::ParallelFor(gbx, [tf, visc, rho]
                                 AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                                 { tf(i,j,k) = tf(i,j,k) / rho(i,j,k) + visc(i,j,k); });
-			    }
-			}
+                            }
+                        }
                     }
                 }
 

--- a/Source/MacProj.cpp
+++ b/Source/MacProj.cpp
@@ -692,13 +692,64 @@ MacProj::mac_sync_compute (int                   level,
                     else  // Scalars
                     {
                         auto const& visc = scal_visc_terms[Smfi].const_array(comp-AMREX_SPACEDIM);
-                        auto const& S    = Smf.const_array(Smfi,comp);
-                        auto const& divu = divu_fp -> const_array(Smfi);
-                        amrex::ParallelFor(gbx, [tf, visc, S, divu]
-                        AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-                        {
-                            tf(i,j,k) += visc(i,j,k) - S(i,j,k) * divu(i,j,k);
-                        });
+                        // auto const& S    = Smf.const_array(Smfi,comp);
+                        // auto const& divu = divu_fp -> const_array(Smfi);
+                        // amrex::ParallelFor(gbx, [tf, visc, S, divu]
+                        // AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                        // {
+			//     // FIXME??? I think this S divU is a vestige of the old
+			//     // Godunov that only computed a convective term, and the
+			//     // adjustement for conservative was here. But now all this
+			//     // should be contained in Godunov...
+			//     // Or maybe the deal was that the tracer was always convective
+			//     // but could choose to do conservative differencing and then
+			//     // use S divU to get back to a passively advected scalar???
+                        //     tf(i,j,k) += visc(i,j,k) - S(i,j,k) * divu(i,j,k);
+                        // });
+
+			auto const& rho = Smf.const_array(Smfi,Density); 
+			
+			if ( NavierStokesBase::do_temp && comp==NavierStokesBase::Temp )
+			{
+			    //
+			    // Solving
+			    //   dT/dt + U dot del T = ( del dot lambda grad T + H_T ) / (rho c_p)
+			    // with tforces = H_T/c_p (since it's always density-weighted), and
+			    // visc = del dot mu grad T, where mu = lambda/c_p
+			    //
+			    amrex::ParallelFor(gbx, [tf, visc, rho]
+                            AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+			    { tf(i,j,k) = ( tf(i,j,k) + visc(i,j,k) ) / rho(i,j,k); });
+			}
+			else
+			{
+			    if (advectionType[comp] == Conservative)
+			    {
+				//
+				// For tracers, Solving
+				//   dS/dt + del dot (U S) = del dot beta grad (S/rho) + rho H_q
+				// where S = rho q, q is a concentration
+				// tforces = rho H_q (since it's always density-weighted)
+				// visc = del dot beta grad (S/rho)
+				//
+				amrex::ParallelFor(gbx, [tf, visc]
+                                AMREX_GPU_DEVICE (int i, int j, int k ) noexcept
+                                { tf(i,j,k) += visc(i,j,k); });
+			    }
+			    else
+			    {
+				//
+				// Solving
+				//   dS/dt + U dot del S = del dot beta grad S + H_q
+				// where S = q, q is a concentration
+				// tforces = rho H_q (since it's always density-weighted)
+				// visc = del dot beta grad S
+				//
+				amrex::ParallelFor(gbx, [tf, visc, rho]
+                                AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                                { tf(i,j,k) = tf(i,j,k) / rho(i,j,k) + visc(i,j,k); });
+			    }
+			}
                     }
                 }
 

--- a/Source/NavierStokes.cpp
+++ b/Source/NavierStokes.cpp
@@ -764,8 +764,6 @@ NavierStokes::scalar_advection (Real dt,
                 auto const& tf    = forcing_term.array(S_mfi,n);
                 auto const& visc  = visc_terms.const_array(S_mfi,n);
                 auto const& rho = Smf.const_array(S_mfi); //Previous time, nghost_state() grow cells filled. It's always true that nghost_state > nghost_force.
-                auto const& divu  = divu_fp -> const_array(S_mfi);
-                auto const& S     = Smf.array(S_mfi);
 
 		if ( do_temp && n+fscalar==Temp )
 		{
@@ -790,7 +788,7 @@ NavierStokes::scalar_advection (Real dt,
 		    // tforces = rho H_q (since it's always density-weighted)
 		    // visc = del dot beta grad (S/rho)
 		    //
-                    amrex::ParallelFor(force_bx, [tf, visc, S, divu, rho]
+                    amrex::ParallelFor(force_bx, [tf, visc]
                     AMREX_GPU_DEVICE (int i, int j, int k ) noexcept
                     { tf(i,j,k) += visc(i,j,k); });
 		  }


### PR DESCRIPTION
During the MAC sync, we need to reconstruct the edge states exactly
as we made them during the advection step of advance. This was not
happening correctly for the scalars when using Godunov with divU!=0
or, for divU=0, non-conservative scalars with external forcing.

This does not affect the mac_sync_compute version where edge states
are passed in and not recomputed.