### PR TITLE
Add BDS to GNUMake header directories

### DIFF
--- a/Exec/Make.IAMR
+++ b/Exec/Make.IAMR
@@ -14,6 +14,7 @@ Blocs	+= $(foreach dir, $(Bdirs), $(TOP)/$(dir))
 
 Hdirs := $(AMREX_HYDRO_HOME)/Slopes
 Hdirs += $(AMREX_HYDRO_HOME)/Utils
+Hdirs += $(AMREX_HYDRO_HOME)/BDS
 Hdirs += $(AMREX_HYDRO_HOME)/MOL
 Hdirs += $(AMREX_HYDRO_HOME)/Godunov
 Hdirs += $(AMREX_HYDRO_HOME)/Projections


### PR DESCRIPTION
This solved an compile error about not finding the library for me. Please check if this was intentionally left out. 