### PR TITLE
Fix bug in #137

### DIFF
--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -5212,9 +5212,9 @@ NavierStokesBase::ComputeAofs ( MultiFab& advc, int a_comp, // Advection term "A
                 }
             }
 
-            AMREX_D_TERM( const auto& fx_fr_fab = cfluxes[0][mfi];,
-                          const auto& fy_fr_fab = cfluxes[1][mfi];,
-                          const auto& fz_fr_fab = cfluxes[2][mfi];);
+            AMREX_D_TERM(FArrayBox fx_fr_fab(fx_fab,amrex::make_alias,flux_comp,ncomp);,
+                         FArrayBox fy_fr_fab(fy_fab,amrex::make_alias,flux_comp,ncomp);,
+                         FArrayBox fz_fr_fab(fz_fab,amrex::make_alias,flux_comp,ncomp););
 
             // Now update the flux registers (inside test on AMREX_USE_EB)
             if ( do_reflux && do_crse_add && (level < parent->finestLevel()) ) {
@@ -5222,14 +5222,14 @@ NavierStokesBase::ComputeAofs ( MultiFab& advc, int a_comp, // Advection term "A
               {
                    getAdvFluxReg(level+1).CrseAdd(mfi,
                        {AMREX_D_DECL(&fx_fr_fab,&fy_fr_fab,&fz_fr_fab)},
-                       dxDp, dt, flux_comp, state_indx, ncomp, amrex::RunOn::Device);
+                       dxDp, dt, 0, state_indx, ncomp, amrex::RunOn::Device);
 
               } else if (flagfab.getType(bx) != FabType::covered ) {
                    getAdvFluxReg(level + 1).CrseAdd(mfi,
                       {AMREX_D_DECL(&fx_fr_fab,&fy_fr_fab,&fz_fr_fab)},
                       dxDp, dt, (*volfrac)[mfi],
                       {AMREX_D_DECL(&(*areafrac[0])[mfi], &(*areafrac[1])[mfi], &(*areafrac[2])[mfi])},
-                      flux_comp, state_indx, ncomp, amrex::RunOn::Device);
+                      0, state_indx, ncomp, amrex::RunOn::Device);
               }
             } // do_reflux && level < finest_level
 
@@ -5245,21 +5245,17 @@ NavierStokesBase::ComputeAofs ( MultiFab& advc, int a_comp, // Advection term "A
               {
                   advflux_reg->FineAdd(mfi,
                      {AMREX_D_DECL(&fx_fr_fab,&fy_fr_fab,&fz_fr_fab)},
-                     dxDp, sync_factor*dt, flux_comp, state_indx, ncomp, amrex::RunOn::Device);
+                     dxDp, sync_factor*dt, 0, state_indx, ncomp, amrex::RunOn::Device);
               } else if (flagfab.getType(bx) != FabType::covered ) {
                   advflux_reg->FineAdd(mfi,
                      {AMREX_D_DECL(&fx_fr_fab,&fy_fr_fab,&fz_fr_fab)},
                      dxDp, sync_factor*dt, (*volfrac)[mfi],
                      {AMREX_D_DECL(&(*areafrac[0])[mfi], &(*areafrac[1])[mfi], &(*areafrac[2])[mfi])},
-                     dm_as_fine, flux_comp, state_indx, ncomp, amrex::RunOn::Device);
+                     dm_as_fine, 0, state_indx, ncomp, amrex::RunOn::Device);
               }
             } // do_reflux && (level > 0)
         } // not covered
 #else
-        AMREX_D_TERM( const auto& fx_fr_fab = cfluxes[0][mfi];,
-                      const auto& fy_fr_fab = cfluxes[1][mfi];,
-                      const auto& fz_fr_fab = cfluxes[2][mfi];);
-
         // This is a hack-y way of testing whether this ComputeAofs call
         // came from the mac_sync (do_crse_add = false)
         // or from the regular advance (do_crse_add = true).  When the call
@@ -5270,13 +5266,13 @@ NavierStokesBase::ComputeAofs ( MultiFab& advc, int a_comp, // Advection term "A
         // Update the flux registers when no EB
         if ( do_reflux && (level < parent->finestLevel()) ) {
                getAdvFluxReg(level+1).CrseAdd(mfi,
-                              {AMREX_D_DECL(&fx_fr_fab,&fy_fr_fab,&fz_fr_fab)},
+                              {AMREX_D_DECL(&fx_fab,&fy_fab,&fz_fab)},
                               dxDp, sync_factor*dt, flux_comp, state_indx, ncomp, amrex::RunOn::Device);
         } // do_reflux && level < finest_level
 
         if ( do_reflux && (level > 0) ) {
               advflux_reg->FineAdd(mfi,
-                              {AMREX_D_DECL(&fx_fr_fab,&fy_fr_fab,&fz_fr_fab)},
+                              {AMREX_D_DECL(&fx_fab,&fy_fab,&fz_fab)},
                                dxDp, sync_factor*dt, flux_comp, state_indx, ncomp, amrex::RunOn::Device);
         } // do_reflux && (level > 0)
 #endif


### PR DESCRIPTION
We do need alias fab in the EB case because dm_as_fine starts with component 0.