### PR TITLE
Disable tracer particles at run time

### DIFF
--- a/Source/NS_setup.cpp
+++ b/Source/NS_setup.cpp
@@ -449,18 +449,20 @@ NavierStokes::variableSetUp ()
     derive_lst.addComponent("avg_pressure",desc_lst,Press_Type,Pressure,1);
 
 #ifdef AMREX_PARTICLES
-    //
-    // The particle count at this level.
-    //
-    derive_lst.add("particle_count",IndexType::TheCellType(),1,
-                   dernull,the_same_box);
-    derive_lst.addComponent("particle_count",desc_lst,State_Type,Density,1);
-    //
-    // The total # of particles at our level or above.
-    //
-    derive_lst.add("total_particle_count",IndexType::TheCellType(),1,
-                   dernull,the_same_box);
-    derive_lst.addComponent("total_particle_count",desc_lst,State_Type,Density,1);
+    if (do_nspc) {
+        //
+        // The particle count at this level.
+        //
+        derive_lst.add("particle_count",IndexType::TheCellType(),1,
+                       dernull,the_same_box);
+        derive_lst.addComponent("particle_count",desc_lst,State_Type,Density,1);
+        //
+        // The total # of particles at our level or above.
+        //
+        derive_lst.add("total_particle_count",IndexType::TheCellType(),1,
+                       dernull,the_same_box);
+        derive_lst.addComponent("total_particle_count",desc_lst,State_Type,Density,1);
+    }
 #endif
 
     //

--- a/Source/NavierStokes.cpp
+++ b/Source/NavierStokes.cpp
@@ -478,7 +478,9 @@ NavierStokes::initData ()
     }
 
 #ifdef AMREX_PARTICLES
-    initParticleData ();
+    if (do_nspc) {
+        initParticleData ();
+    }
 #endif
 }
 

--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -623,7 +623,7 @@ NavierStokesBase::advance_setup (Real /*time*/,
     umac_n_grow = 1;
 
 #ifdef AMREX_PARTICLES
-    if (ncycle > umac_n_grow) {
+    if (ncycle > umac_n_grow && NSPC) {
         umac_n_grow = ncycle;
     }
 #endif
@@ -3813,6 +3813,8 @@ NavierStokesBase::read_particle_params ()
 void
 NavierStokesBase::initParticleData ()
 {
+    if (!do_nspc) { return; }
+
     if (level == 0)
     {
         if (NSPC == 0)


### PR DESCRIPTION
There is a runtime parameter `particles.do_nspc_particles` for disabling particles. But it was not used everywhere. This commit fixes it.