### PR TITLE
Fix HIT IC z-extent: use problo[2] instead of problo[1]

### DIFF
--- a/Tutorials/FlowPastCylinder/inputs.3d.flow_past_cylinder-x
+++ b/Tutorials/FlowPastCylinder/inputs.3d.flow_past_cylinder-x
@@ -7,7 +7,7 @@ max_step                =  -1           # Max number of time steps
 #           SOLVER SETTINGS             #
 #.......................................#
 ns.init_iter       = 3                  # How many initial pressure iterations
-ns.init_vel_iter   = 5                  # How many initial projeciton iterations to ensure velocity satisfies divergence constraint 
+ns.init_vel_iter   = 5                  # How many initial projection iterations to ensure velocity satisfies divergence constraint
 ns.visc_tol        = 1.0e-11            # tolerance for viscous solve
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #         TIME STEP COMPUTATION         #

--- a/Tutorials/FlowPastCylinder/inputs.3d.flow_past_cylinder-y
+++ b/Tutorials/FlowPastCylinder/inputs.3d.flow_past_cylinder-y
@@ -7,7 +7,7 @@ max_step                =  -1           # Max number of time steps
 #           SOLVER SETTINGS             #
 #.......................................#
 ns.init_iter       = 3                  # How many initial pressure iterations
-ns.init_vel_iter   = 5                  # How many initial projeciton iterations to ensure velocity satisfies divergence constraint 
+ns.init_vel_iter   = 5                  # How many initial projection iterations to ensure velocity satisfies divergence constraint
 ns.visc_tol        = 1.0e-11            # tolerance for viscous solve
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #         TIME STEP COMPUTATION         #

--- a/Tutorials/FlowPastCylinder/inputs.3d.flow_past_cylinder-z
+++ b/Tutorials/FlowPastCylinder/inputs.3d.flow_past_cylinder-z
@@ -7,7 +7,7 @@ max_step                =  -1           # Max number of time steps
 #           SOLVER SETTINGS             #
 #.......................................#
 ns.init_iter       = 3                  # How many initial pressure iterations
-ns.init_vel_iter   = 5                  # How many initial projeciton iterations to ensure velocity satisfies divergence constraint 
+ns.init_vel_iter   = 5                  # How many initial projection iterations to ensure velocity satisfies divergence constraint
 ns.visc_tol        = 1.0e-11            # tolerance for viscous solve
 #¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨¨#
 #         TIME STEP COMPUTATION         #

--- a/Tutorials/HIT/prob_init.cpp
+++ b/Tutorials/HIT/prob_init.cpp
@@ -109,7 +109,7 @@ void NavierStokes::init_forced (Box const& vbx,
     const Real Lx    = (probhi[0] - problo[0]);
     const Real Ly    = (probhi[1] - problo[1]);
 #if (AMREX_SPACEDIM == 3)
-    const Real Lz    = (probhi[2] - problo[1]);
+    const Real Lz    = (probhi[2] - problo[2]);
 #else
     const Real Lz    = 1.0;
 #endif


### PR DESCRIPTION
In Tutorials/HIT/prob_init.cpp, Lz was computed as probhi[2]-problo[1], a copy-paste of the Ly line. When problo[1] != problo[2] the initial cos(2*pi*z/Lz) velocity field is not periodic in z, giving a discontinuity across the periodic z boundary at step 0, and disagrees with the forcing, which uses probhi[2]-problo[2] in TurbulentForcing::init_turbulent_forcing and explicitly permits Lz > Lx.

No behavior change for the shipped inputs, which all use symmetric prob_lo.

Fixes #180